### PR TITLE
Fix dashboard subscription downloads

### DIFF
--- a/local/app/api/subscriptions/[id]/config.yaml/route.ts
+++ b/local/app/api/subscriptions/[id]/config.yaml/route.ts
@@ -12,7 +12,7 @@ export async function GET(_request: Request, { params }: RouteContext) {
   return new Response(yaml, {
     headers: {
       "Content-Type": "text/yaml; charset=utf-8",
-      "Content-Disposition": 'attachment; filename="subboost-config.yaml"',
+      "Content-Disposition": 'attachment; filename="subboost-config"',
       "Cache-Control": "no-store",
     },
   });

--- a/local/app/api/subscriptions/[id]/config.yaml/route.ts
+++ b/local/app/api/subscriptions/[id]/config.yaml/route.ts
@@ -12,6 +12,7 @@ export async function GET(_request: Request, { params }: RouteContext) {
   return new Response(yaml, {
     headers: {
       "Content-Type": "text/yaml; charset=utf-8",
+      "Content-Disposition": 'attachment; filename="subboost-config.yaml"',
       "Cache-Control": "no-store",
     },
   });

--- a/local/app/api/subscriptions/[id]/config.yaml/route.ts
+++ b/local/app/api/subscriptions/[id]/config.yaml/route.ts
@@ -1,5 +1,6 @@
 import { apiError } from "@local/lib/http";
 import { generateSubscriptionYaml } from "@local/lib/subscription-service";
+import { buildSubscriptionResponseHeaders } from "@subboost/server-core/subscription";
 
 type RouteContext = {
   params: Promise<{ id: string }>;
@@ -7,13 +8,14 @@ type RouteContext = {
 
 export async function GET(_request: Request, { params }: RouteContext) {
   const { id: token } = await params;
-  const yaml = await generateSubscriptionYaml(token);
-  if (!yaml) return apiError("Subscription YAML not found.", "NOT_FOUND", 404);
-  return new Response(yaml, {
-    headers: {
-      "Content-Type": "text/yaml; charset=utf-8",
-      "Content-Disposition": 'attachment; filename="subboost-config"',
-      "Cache-Control": "no-store",
-    },
+  const result = await generateSubscriptionYaml(token);
+  if (!result) return apiError("Subscription YAML not found.", "NOT_FOUND", 404);
+  return new Response(result.yaml, {
+    headers: buildSubscriptionResponseHeaders(result.name, result.subscriptionInfo, {
+      cacheControl: "no-store",
+      cacheExpirySeconds: result.cacheExpirySeconds,
+      autoUpdateIntervalSeconds: result.autoUpdateIntervalSeconds,
+      isAdmin: result.isAdmin,
+    }),
   });
 }

--- a/local/app/dashboard/page.tsx
+++ b/local/app/dashboard/page.tsx
@@ -7,6 +7,16 @@ import { readJsonResponse } from "@subboost/ui/product/client-response";
 import type { RefreshSubscriptionResponse, Subscription } from "@subboost/ui/dashboard/dashboard-types";
 import { LOCAL_AUTO_UPDATE_POLICY } from "@local/lib/auto-update-policy";
 
+function resolveLocalDashboardDownloadUrl(subscription: Subscription): string {
+  try {
+    const url = new URL(subscription.subscriptionUrl, window.location.href);
+    if (url.pathname.includes("/api/subscriptions/")) {
+      return `${window.location.origin}${url.pathname}${url.search}`;
+    }
+  } catch {}
+  return subscription.subscriptionUrl;
+}
+
 const localDashboardAdapter: DashboardSurfaceAdapter = {
   loginHref: "/login",
   newSubscriptionHref: "/?newSubscription=1",
@@ -39,6 +49,7 @@ const localDashboardAdapter: DashboardSurfaceAdapter = {
     });
     await readJsonResponse<{ error?: string }>(response, "保存失败");
   },
+  resolveDownloadUrl: resolveLocalDashboardDownloadUrl,
 };
 
 export default function DashboardPage() {

--- a/local/app/local-pages.test.ts
+++ b/local/app/local-pages.test.ts
@@ -147,11 +147,22 @@ describe("local app pages and adapters", () => {
 
     renderToStaticMarkup(React.createElement(DashboardPage));
     const adapter = mocks.dashboardAdapter;
+    vi.stubGlobal("window", {
+      location: {
+        href: "http://23.80.90.37:31401/dashboard",
+        origin: "http://23.80.90.37:31401",
+      },
+    });
 
     await expect(adapter.fetchSubscriptions()).resolves.toEqual([{ id: "sub-1" }]);
     await expect(adapter.deleteSubscription("sub 1")).resolves.toBeUndefined();
     await expect(adapter.refreshSubscription("sub 1")).resolves.toEqual({ ok: true });
     await expect(adapter.updateSubscriptionSettings("sub 1", { name: "Sub" })).resolves.toBeUndefined();
+    expect(
+      adapter.resolveDownloadUrl({
+        subscriptionUrl: "http://localhost:3001/api/subscriptions/token-1/config.yaml",
+      })
+    ).toBe("http://23.80.90.37:31401/api/subscriptions/token-1/config.yaml");
     expect(adapter.autoUpdateIntervalPolicy).toEqual({
       defaultHours: 12,
       minHours: 0.1,

--- a/local/src/lib/subscription-service.test.ts
+++ b/local/src/lib/subscription-service.test.ts
@@ -464,7 +464,14 @@ describe("local subscription service", () => {
   });
 
   it("generates YAML and updates access time when a subscription has nodes or proxy providers", async () => {
-    await expect(generateSubscriptionYaml("token-1")).resolves.toBe("mixed-port: 7890\n");
+    await expect(generateSubscriptionYaml("token-1")).resolves.toMatchObject({
+      yaml: "mixed-port: 7890\n",
+      name: "Saved",
+      subscriptionInfo: { upload: 2048, total: 4096 },
+      cacheExpirySeconds: 3600,
+      autoUpdateIntervalSeconds: 86400,
+      isAdmin: true,
+    });
     expect(mocks.buildGenerateOptionsFromConfig).toHaveBeenCalledWith(
       expect.objectContaining({ sources: expect.any(Array) }),
       expect.objectContaining({ nodes: [expect.objectContaining({ name: "Node" })], proxyProviders: null })
@@ -487,6 +494,6 @@ describe("local subscription service", () => {
       row({ encryptedNodes: JSON.stringify([]), encryptedConfig: JSON.stringify({ proxyProviders: { provider: {} } }) })
     );
     mocks.buildProxyProvidersFromConfig.mockReturnValueOnce({ provider: { url: "https://example.com/provider.yaml" } });
-    await expect(generateSubscriptionYaml("provider-only")).resolves.toBe("mixed-port: 7890\n");
+    await expect(generateSubscriptionYaml("provider-only")).resolves.toMatchObject({ yaml: "mixed-port: 7890\n" });
   });
 });

--- a/local/src/lib/subscription-service.ts
+++ b/local/src/lib/subscription-service.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { generateClashYaml } from "@subboost/core/generator";
 import { buildGenerateOptionsFromConfig, getEffectiveTestOptions } from "@subboost/core/subscription/config-utils";
 import { buildProxyProvidersFromConfig } from "@subboost/core/subscription/proxy-providers";
+import type { SubscriptionResponseInfo } from "@subboost/core/subscription/subscription-response-info";
 import type { ParsedNode } from "@subboost/core/types/node";
 import {
   buildManualRefreshFailureResponse,
@@ -85,6 +86,15 @@ export type SubscriptionDetail = SubscriptionSummary & {
   nodes: ParsedNode[];
   config: Record<string, unknown>;
   subscriptionInfo: Record<string, unknown>;
+};
+
+export type GeneratedSubscriptionYaml = {
+  yaml: string;
+  name: string;
+  subscriptionInfo: SubscriptionResponseInfo;
+  cacheExpirySeconds: number;
+  autoUpdateIntervalSeconds: number | null;
+  isAdmin: boolean;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -357,7 +367,7 @@ export async function refreshSubscription(ownerId: string, id: string) {
   };
 }
 
-export async function generateSubscriptionYaml(token: string): Promise<string | null> {
+export async function generateSubscriptionYaml(token: string): Promise<GeneratedSubscriptionYaml | null> {
   const row = await prisma.subscription.findUnique({ where: { token }, include: { autoUpdateState: true } });
   if (!row) return null;
   const secrets = readSubscriptionSecrets(row);
@@ -371,5 +381,12 @@ export async function generateSubscriptionYaml(token: string): Promise<string | 
     })
   );
   await prisma.subscription.update({ where: { id: row.id }, data: { lastAccessedAt: new Date() } });
-  return yaml;
+  return {
+    yaml,
+    name: row.name,
+    subscriptionInfo: secrets.subscriptionInfo,
+    cacheExpirySeconds: CACHE_TTL_SECONDS,
+    autoUpdateIntervalSeconds: row.autoUpdateInterval,
+    isAdmin: true,
+  };
 }

--- a/local/test/subscription-route-contract.test.ts
+++ b/local/test/subscription-route-contract.test.ts
@@ -138,7 +138,7 @@ describe("local subscription routes", () => {
       params: Promise.resolve({ id: "token-1" }),
     });
     expect(pluralResponse.status).toBe(200);
-    expect(pluralResponse.headers.get("content-disposition")).toBe('attachment; filename="subboost-config.yaml"');
+    expect(pluralResponse.headers.get("content-disposition")).toBe('attachment; filename="subboost-config"');
     expect(await pluralResponse.text()).toBe("mixed-port: 7890\n");
     expect(generateSubscriptionYaml).toHaveBeenCalledWith("token-1");
   });

--- a/local/test/subscription-route-contract.test.ts
+++ b/local/test/subscription-route-contract.test.ts
@@ -138,6 +138,7 @@ describe("local subscription routes", () => {
       params: Promise.resolve({ id: "token-1" }),
     });
     expect(pluralResponse.status).toBe(200);
+    expect(pluralResponse.headers.get("content-disposition")).toBe('attachment; filename="subboost-config.yaml"');
     expect(await pluralResponse.text()).toBe("mixed-port: 7890\n");
     expect(generateSubscriptionYaml).toHaveBeenCalledWith("token-1");
   });

--- a/local/test/subscription-route-contract.test.ts
+++ b/local/test/subscription-route-contract.test.ts
@@ -91,7 +91,19 @@ beforeEach(() => {
   vi.mocked(getCurrentAdmin).mockResolvedValue(admin);
   vi.mocked(createSubscription).mockResolvedValue(subscription as never);
   vi.mocked(deleteSubscription).mockResolvedValue(true);
-  vi.mocked(generateSubscriptionYaml).mockResolvedValue("mixed-port: 7890\n");
+  vi.mocked(generateSubscriptionYaml).mockResolvedValue({
+    yaml: "mixed-port: 7890\n",
+    name: "Main",
+    subscriptionInfo: {
+      upload: 64,
+      download: 128,
+      total: 1024,
+      expire: 1781635200,
+    },
+    cacheExpirySeconds: 3600,
+    autoUpdateIntervalSeconds: 86400,
+    isAdmin: true,
+  } as never);
   vi.mocked(getSubscription).mockResolvedValue(subscription as never);
   vi.mocked(listSubscriptions).mockResolvedValue([subscription] as never);
   vi.mocked(refreshSubscription).mockResolvedValue({
@@ -138,7 +150,12 @@ describe("local subscription routes", () => {
       params: Promise.resolve({ id: "token-1" }),
     });
     expect(pluralResponse.status).toBe(200);
-    expect(pluralResponse.headers.get("content-disposition")).toBe('attachment; filename="subboost-config"');
+    expect(pluralResponse.headers.get("content-disposition")).toContain('filename="Main"');
+    expect(pluralResponse.headers.get("content-disposition")).not.toContain(".yaml");
+    expect(pluralResponse.headers.get("subscription-userinfo")).toBe(
+      "upload=64; download=128; total=1024; expire=1781635200"
+    );
+    expect(pluralResponse.headers.get("profile-update-interval")).toBe("24");
     expect(await pluralResponse.text()).toBe("mixed-port: 7890\n");
     expect(generateSubscriptionYaml).toHaveBeenCalledWith("token-1");
   });

--- a/packages/server-core/src/subscription/index.ts
+++ b/packages/server-core/src/subscription/index.ts
@@ -8,6 +8,7 @@ export * from "./fetch-profile-heuristics";
 export * from "./manual-refresh-response";
 export * from "./refresh-cache-result";
 export * from "./refresh-node-snapshot";
+export * from "./response-headers";
 export * from "./saved-sources";
 export * from "./source-import";
 export * from "./ssrf-ip";

--- a/packages/server-core/src/subscription/response-headers.test.ts
+++ b/packages/server-core/src/subscription/response-headers.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSubscriptionResponseHeaders } from "./response-headers";
+
+describe("subscription response headers", () => {
+  it("uses the subscription name without adding yaml to client-visible filenames", () => {
+    const headers = buildSubscriptionResponseHeaders("我的配置 2026/06/17.yaml", {}, { isAdmin: false });
+
+    expect(headers["content-disposition"]).not.toContain("filename=");
+    expect(headers["content-disposition"]).toContain("filename*=UTF-8''");
+    expect(decodeURIComponent(headers["content-disposition"].split("filename*=UTF-8''")[1])).toBe(
+      "我的配置 2026/06/17"
+    );
+    expect(headers["content-disposition"]).not.toContain(".yaml");
+  });
+
+  it("keeps a plain filename fallback for safe ASCII subscription names", () => {
+    const headers = buildSubscriptionResponseHeaders("Main", {}, { isAdmin: true });
+
+    expect(headers["content-disposition"]).toBe("attachment; filename=\"Main\"; filename*=UTF-8''Main");
+  });
+
+  it("serializes traffic and expiry metadata for proxy clients", () => {
+    const headers = buildSubscriptionResponseHeaders(
+      "Main",
+      {
+        upload: 1024,
+        download: 2048,
+        total: 4096,
+        expire: 1781635200,
+        planName: "Pro",
+        profileWebPageUrl: "https://example.com/account",
+      },
+      {
+        cacheControl: "no-store",
+        cacheExpirySeconds: 3600,
+        autoUpdateIntervalSeconds: 86400,
+        isAdmin: true,
+      }
+    );
+
+    expect(headers["cache-control"]).toBe("no-store");
+    expect(headers["subscription-userinfo"]).toBe("upload=1024; download=2048; total=4096; expire=1781635200");
+    expect(headers["profile-update-interval"]).toBe("24");
+    expect(headers["plan-name"]).toBe("Pro");
+    expect(headers["profile-web-page-url"]).toBe("https://example.com/account");
+  });
+});

--- a/packages/server-core/src/subscription/response-headers.ts
+++ b/packages/server-core/src/subscription/response-headers.ts
@@ -1,0 +1,82 @@
+import {
+  resolveClientProfileUpdateIntervalSeconds,
+  type SubscriptionResponseInfo,
+} from "@subboost/core/subscription/subscription-response-info";
+
+type BuildSubscriptionResponseHeadersOptions = {
+  cacheControl?: string;
+  cacheExpirySeconds?: number;
+  autoUpdateIntervalSeconds?: number | null;
+  isAdmin: boolean;
+};
+
+function normalizeHeaderFileNameBase(name: string): string {
+  return (
+    String(name || "config")
+      .trim()
+      .replace(/[\r\n"]/g, "")
+      .replace(/\.(?:ya?ml)$/i, "")
+      .slice(0, 80) || "config"
+  );
+}
+
+function normalizeAsciiFileNameBase(name: string): string {
+  return (
+    name
+      // 仅保留可打印 ASCII，避免部分客户端忽略 filename* 时出现乱码。
+      .replace(/[^\x20-\x7E]+/g, "")
+      // 去掉 Windows/macOS 常见非法文件名字符。
+      .replace(/[<>:"/\\|?*]+/g, "")
+      .trim()
+      .replace(/\s+/g, "_")
+      .slice(0, 60) || "config"
+  );
+}
+
+function serializeSubscriptionUserInfo(subscriptionInfo: SubscriptionResponseInfo): string | null {
+  const parts: string[] = [];
+  if (subscriptionInfo.upload !== undefined) parts.push(`upload=${subscriptionInfo.upload}`);
+  if (subscriptionInfo.download !== undefined) parts.push(`download=${subscriptionInfo.download}`);
+  if (subscriptionInfo.total !== undefined) parts.push(`total=${subscriptionInfo.total}`);
+  if (subscriptionInfo.expire !== undefined) parts.push(`expire=${subscriptionInfo.expire}`);
+  return parts.length > 0 ? parts.join("; ") : null;
+}
+
+function buildContentDisposition(name: string): string {
+  const safeNameBase = normalizeHeaderFileNameBase(name);
+  const asciiFileNameBase = normalizeAsciiFileNameBase(safeNameBase);
+  const encodedFileName = encodeURIComponent(safeNameBase);
+  if (asciiFileNameBase === safeNameBase) {
+    return `attachment; filename=\"${asciiFileNameBase}\"; filename*=UTF-8''${encodedFileName}`;
+  }
+  return `attachment; filename*=UTF-8''${encodedFileName}`;
+}
+
+export function buildSubscriptionResponseHeaders(
+  name: string,
+  subscriptionInfo: SubscriptionResponseInfo,
+  options: BuildSubscriptionResponseHeadersOptions
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "content-type": "text/yaml;charset=utf-8",
+    // 订阅客户端可能把 filename 当作订阅显示名，响应头不要补 .yaml。
+    "content-disposition": buildContentDisposition(name),
+    "cache-control": options.cacheControl ?? "no-cache",
+  };
+
+  const recommendedIntervalSeconds = resolveClientProfileUpdateIntervalSeconds({
+    cacheExpirySeconds: options.cacheExpirySeconds,
+    autoUpdateIntervalSeconds: options.autoUpdateIntervalSeconds,
+    isAdmin: options.isAdmin,
+  });
+  if (typeof recommendedIntervalSeconds === "number" && Number.isFinite(recommendedIntervalSeconds)) {
+    headers["profile-update-interval"] = String(Math.max(1, Math.ceil(recommendedIntervalSeconds / 3600)));
+  }
+
+  const userInfoHeader = serializeSubscriptionUserInfo(subscriptionInfo);
+  if (userInfoHeader) headers["subscription-userinfo"] = userInfoHeader;
+  if (subscriptionInfo.profileWebPageUrl) headers["profile-web-page-url"] = subscriptionInfo.profileWebPageUrl;
+  if (subscriptionInfo.planName) headers["plan-name"] = subscriptionInfo.planName;
+
+  return headers;
+}

--- a/packages/ui/src/dashboard/subscription-dashboard-surface.test.ts
+++ b/packages/ui/src/dashboard/subscription-dashboard-surface.test.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   captures: {} as Record<string, any>,
@@ -189,6 +189,39 @@ async function flushPromises() {
   await Promise.resolve();
 }
 
+function stubDocumentActions() {
+  const anchor = {
+    href: "",
+    download: "",
+    rel: "",
+    style: {} as Record<string, string>,
+    click: vi.fn(),
+    remove: vi.fn(),
+  };
+  const textarea = {
+    value: "",
+    style: {} as Record<string, string>,
+    setAttribute: vi.fn(),
+    select: vi.fn(),
+    remove: vi.fn(),
+  };
+  const appendChild = vi.fn();
+  const execCommand = vi.fn(() => true);
+  const createElement = vi.fn((tagName: string) => {
+    if (tagName === "a") return anchor;
+    if (tagName === "textarea") return textarea;
+    throw new Error(`Unexpected element: ${tagName}`);
+  });
+
+  vi.stubGlobal("document", {
+    createElement,
+    body: { appendChild },
+    execCommand,
+  });
+
+  return { anchor, textarea, appendChild, createElement, execCommand };
+}
+
 describe("SubscriptionDashboardSurface", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -206,6 +239,10 @@ describe("SubscriptionDashboardSurface", () => {
       getItem: vi.fn(() => null),
       setItem: vi.fn(),
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("renders loading, login prompt, empty state, stats, and quick actions", () => {
@@ -250,7 +287,8 @@ describe("SubscriptionDashboardSurface", () => {
   it("copies, deletes, refreshes, and opens settings for subscriptions", async () => {
     const { setters, adapter } = renderSurface(createAdapter(), { 0: [subscription, disabledSubscription], 1: false, 2: null, 3: null });
 
-    await mocks.captures.buttons[4].onClick();
+    await mocks.captures.buttons.find((props: any) => props.title === "复制订阅链接").onClick();
+    await flushPromises();
     expect(mocks.clipboardWriteText).toHaveBeenCalledWith("https://example.com/sub");
     expect(setters[2]).toHaveBeenCalledWith("sub-1");
     expect(setters[2]).toHaveBeenCalledWith(null);
@@ -281,6 +319,66 @@ describe("SubscriptionDashboardSurface", () => {
     expect(setters[5]).toHaveBeenCalledWith(disabledSubscription);
     expect(setters[8]).toHaveBeenCalledWith(false);
     expect(setters[9]).toHaveBeenCalledWith(24);
+  });
+
+  it("falls back to legacy copy for non-secure self-host origins", async () => {
+    const dom = stubDocumentActions();
+    vi.stubGlobal("navigator", {});
+    const { setters } = renderSurface(createAdapter(), { 0: [subscription], 1: false, 2: null, 3: null });
+
+    await mocks.captures.buttons.find((props: any) => props.title === "复制订阅链接").onClick();
+    await flushPromises();
+
+    expect(dom.createElement).toHaveBeenCalledWith("textarea");
+    expect(dom.textarea.value).toBe("https://example.com/sub");
+    expect(dom.textarea.select).toHaveBeenCalled();
+    expect(dom.execCommand).toHaveBeenCalledWith("copy");
+    expect(dom.textarea.remove).toHaveBeenCalled();
+    expect(setters[2]).toHaveBeenCalledWith("sub-1");
+    expect(mocks.toast).not.toHaveBeenCalledWith(expect.objectContaining({ variant: "destructive" }));
+  });
+
+  it("downloads subscription YAML with a yaml filename instead of opening a new tab", async () => {
+    const dom = stubDocumentActions();
+    const blob = new Blob(["mixed-port: 7890\n"], { type: "text/yaml" });
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 200, blob: vi.fn(async () => blob) }));
+    const createObjectURL = vi.fn(() => "blob:subboost-config");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("URL", { createObjectURL, revokeObjectURL });
+
+    renderSurface(createAdapter(), { 0: [subscription], 1: false, 2: null, 3: null });
+    await mocks.captures.buttons.find((props: any) => props.title === "下载订阅配置").onClick();
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalledWith("https://example.com/sub");
+    expect(createObjectURL).toHaveBeenCalledWith(blob);
+    expect(dom.createElement).toHaveBeenCalledWith("a");
+    expect(dom.anchor.href).toBe("blob:subboost-config");
+    expect(dom.anchor.download).toBe("Primary.yaml");
+    expect(dom.anchor.rel).toBe("noopener noreferrer");
+    expect(dom.anchor.click).toHaveBeenCalled();
+    expect(dom.anchor.remove).toHaveBeenCalled();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:subboost-config");
+  });
+
+  it("falls back to direct browser download when fetching the YAML fails", async () => {
+    const dom = stubDocumentActions();
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("cors");
+    }));
+
+    renderSurface(createAdapter(), { 0: [subscription], 1: false, 2: null, 3: null });
+    await mocks.captures.buttons.find((props: any) => props.title === "下载订阅配置").onClick();
+    await flushPromises();
+
+    expect(dom.anchor.href).toBe("https://example.com/sub");
+    expect(dom.anchor.download).toBe("Primary.yaml");
+    expect(dom.anchor.click).toHaveBeenCalled();
+    expect(mocks.toast).toHaveBeenCalledWith(expect.objectContaining({
+      title: "已改用浏览器直接下载",
+      variant: "warning",
+    }));
   });
 
   it("guards cancelled delete and in-flight refresh failures", async () => {

--- a/packages/ui/src/dashboard/subscription-dashboard-surface.test.ts
+++ b/packages/ui/src/dashboard/subscription-dashboard-surface.test.ts
@@ -388,7 +388,7 @@ describe("SubscriptionDashboardSurface", () => {
     }));
   });
 
-  it("fetches cross-origin subscription links through the current origin for downloads", async () => {
+  it("uses the adapter download URL resolver before fetching subscription YAML", async () => {
     const dom = stubDocumentActions();
     const blob = new Blob(["mixed-port: 7890\n"], { type: "text/yaml" });
     const fetchMock = vi.fn(async () => ({ ok: true, status: 200, blob: vi.fn(async () => blob) }));
@@ -398,8 +398,13 @@ describe("SubscriptionDashboardSurface", () => {
     TestURL.revokeObjectURL = vi.fn();
     vi.stubGlobal("URL", TestURL);
 
-    renderSurface(createAdapter(), {
-      0: [{ ...subscription, subscriptionUrl: "https://subscription.example.test/api/subscription/token-1?download=1" }],
+    const crossOriginSubscription = {
+      ...subscription,
+      subscriptionUrl: "https://subscription.example.test/download/token-1?download=1",
+    };
+    const resolveDownloadUrl = vi.fn(() => "http://localhost/download/token-1?download=1");
+    renderSurface(createAdapter({ resolveDownloadUrl }), {
+      0: [crossOriginSubscription],
       1: false,
       2: null,
       3: null,
@@ -407,7 +412,8 @@ describe("SubscriptionDashboardSurface", () => {
     await mocks.captures.buttons.find((props: any) => props.title === "下载订阅配置").onClick();
     await flushPromises();
 
-    expect(fetchMock).toHaveBeenCalledWith("http://localhost/api/subscription/token-1?download=1");
+    expect(resolveDownloadUrl).toHaveBeenCalledWith(crossOriginSubscription);
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost/download/token-1?download=1");
     expect(dom.anchor.download).toBe("Primary.yaml");
   });
 

--- a/packages/ui/src/dashboard/subscription-dashboard-surface.test.ts
+++ b/packages/ui/src/dashboard/subscription-dashboard-surface.test.ts
@@ -239,6 +239,12 @@ describe("SubscriptionDashboardSurface", () => {
       getItem: vi.fn(() => null),
       setItem: vi.fn(),
     });
+    vi.stubGlobal("window", {
+      location: {
+        href: "http://localhost/dashboard",
+        origin: "http://localhost",
+      },
+    });
   });
 
   afterEach(() => {
@@ -344,8 +350,11 @@ describe("SubscriptionDashboardSurface", () => {
     const fetchMock = vi.fn(async () => ({ ok: true, status: 200, blob: vi.fn(async () => blob) }));
     const createObjectURL = vi.fn(() => "blob:subboost-config");
     const revokeObjectURL = vi.fn();
+    class TestURL extends URL {}
+    TestURL.createObjectURL = createObjectURL;
+    TestURL.revokeObjectURL = revokeObjectURL;
     vi.stubGlobal("fetch", fetchMock);
-    vi.stubGlobal("URL", { createObjectURL, revokeObjectURL });
+    vi.stubGlobal("URL", TestURL);
 
     renderSurface(createAdapter(), { 0: [subscription], 1: false, 2: null, 3: null });
     await mocks.captures.buttons.find((props: any) => props.title === "下载订阅配置").onClick();
@@ -377,6 +386,29 @@ describe("SubscriptionDashboardSurface", () => {
       title: "下载失败",
       variant: "destructive",
     }));
+  });
+
+  it("fetches cross-origin subscription links through the current origin for downloads", async () => {
+    const dom = stubDocumentActions();
+    const blob = new Blob(["mixed-port: 7890\n"], { type: "text/yaml" });
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 200, blob: vi.fn(async () => blob) }));
+    vi.stubGlobal("fetch", fetchMock);
+    class TestURL extends URL {}
+    TestURL.createObjectURL = vi.fn(() => "blob:subboost-config");
+    TestURL.revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", TestURL);
+
+    renderSurface(createAdapter(), {
+      0: [{ ...subscription, subscriptionUrl: "https://subscription.example.test/api/subscription/token-1?download=1" }],
+      1: false,
+      2: null,
+      3: null,
+    });
+    await mocks.captures.buttons.find((props: any) => props.title === "下载订阅配置").onClick();
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost/api/subscription/token-1?download=1");
+    expect(dom.anchor.download).toBe("Primary.yaml");
   });
 
   it("guards cancelled delete and in-flight refresh failures", async () => {

--- a/packages/ui/src/dashboard/subscription-dashboard-surface.test.ts
+++ b/packages/ui/src/dashboard/subscription-dashboard-surface.test.ts
@@ -362,7 +362,7 @@ describe("SubscriptionDashboardSurface", () => {
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:subboost-config");
   });
 
-  it("falls back to direct browser download when fetching the YAML fails", async () => {
+  it("reports download failures without opening the subscription URL", async () => {
     const dom = stubDocumentActions();
     vi.stubGlobal("fetch", vi.fn(async () => {
       throw new Error("cors");
@@ -372,12 +372,10 @@ describe("SubscriptionDashboardSurface", () => {
     await mocks.captures.buttons.find((props: any) => props.title === "下载订阅配置").onClick();
     await flushPromises();
 
-    expect(dom.anchor.href).toBe("https://example.com/sub");
-    expect(dom.anchor.download).toBe("Primary.yaml");
-    expect(dom.anchor.click).toHaveBeenCalled();
+    expect(dom.createElement).not.toHaveBeenCalledWith("a");
     expect(mocks.toast).toHaveBeenCalledWith(expect.objectContaining({
-      title: "已改用浏览器直接下载",
-      variant: "warning",
+      title: "下载失败",
+      variant: "destructive",
     }));
   });
 

--- a/packages/ui/src/dashboard/subscription-dashboard-surface.tsx
+++ b/packages/ui/src/dashboard/subscription-dashboard-surface.tsx
@@ -55,6 +55,7 @@ export type DashboardSurfaceAdapter = {
   deleteSubscription: (id: string) => Promise<void>;
   refreshSubscription: (id: string) => Promise<RefreshSubscriptionResponse>;
   updateSubscriptionSettings: (id: string, payload: UpdateSettingsPayload) => Promise<void>;
+  resolveDownloadUrl?: (subscription: Subscription) => string;
   renderAnnouncement?: (context: { user: User }) => React.ReactNode;
   renderHeaderActions?: (context: { user: User }) => React.ReactNode;
   renderExtraQuickActions?: (context: { user: User }) => React.ReactNode;
@@ -86,16 +87,6 @@ function triggerBrowserDownload(href: string, filename: string) {
   document.body.appendChild(anchor);
   anchor.click();
   anchor.remove();
-}
-
-function buildSameOriginDownloadUrl(subscriptionUrl: string): string {
-  try {
-    const url = new URL(subscriptionUrl, window.location.href);
-    if (!url.pathname.includes("/api/subscription")) return subscriptionUrl;
-    return `${window.location.origin}${url.pathname}${url.search}`;
-  } catch {
-    return subscriptionUrl;
-  }
 }
 
 async function copyText(text: string): Promise<boolean> {
@@ -217,7 +208,7 @@ export function SubscriptionDashboardSurface({ adapter }: Props) {
   const downloadSubscription = async (subscription: Subscription) => {
     const filename = buildYamlDownloadFilename(subscription.name);
     try {
-      const response = await fetch(buildSameOriginDownloadUrl(subscription.subscriptionUrl));
+      const response = await fetch(adapter.resolveDownloadUrl?.(subscription) ?? subscription.subscriptionUrl);
       if (!response.ok) throw new Error(`Download failed with status ${response.status}`);
       const blob = await response.blob();
       const objectUrl = URL.createObjectURL(blob);

--- a/packages/ui/src/dashboard/subscription-dashboard-surface.tsx
+++ b/packages/ui/src/dashboard/subscription-dashboard-surface.tsx
@@ -88,6 +88,16 @@ function triggerBrowserDownload(href: string, filename: string) {
   anchor.remove();
 }
 
+function buildSameOriginDownloadUrl(subscriptionUrl: string): string {
+  try {
+    const url = new URL(subscriptionUrl, window.location.href);
+    if (!url.pathname.includes("/api/subscription")) return subscriptionUrl;
+    return `${window.location.origin}${url.pathname}${url.search}`;
+  } catch {
+    return subscriptionUrl;
+  }
+}
+
 async function copyText(text: string): Promise<boolean> {
   try {
     if (navigator.clipboard?.writeText) {
@@ -207,7 +217,7 @@ export function SubscriptionDashboardSurface({ adapter }: Props) {
   const downloadSubscription = async (subscription: Subscription) => {
     const filename = buildYamlDownloadFilename(subscription.name);
     try {
-      const response = await fetch(subscription.subscriptionUrl);
+      const response = await fetch(buildSameOriginDownloadUrl(subscription.subscriptionUrl));
       if (!response.ok) throw new Error(`Download failed with status ${response.status}`);
       const blob = await response.blob();
       const objectUrl = URL.createObjectURL(blob);

--- a/packages/ui/src/dashboard/subscription-dashboard-surface.tsx
+++ b/packages/ui/src/dashboard/subscription-dashboard-surface.tsx
@@ -65,6 +65,54 @@ type Props = {
   adapter: DashboardSurfaceAdapter;
 };
 
+function buildYamlDownloadFilename(name: string): string {
+  const base =
+    String(name || "subboost-config")
+      .trim()
+      .replace(/[\r\n]/g, " ")
+      .replace(/[<>:"/\\|?*]+/g, "")
+      .replace(/\s+/g, "_")
+      .replace(/\.(?:ya?ml)$/i, "")
+      .slice(0, 80) || "subboost-config";
+  return `${base}.yaml`;
+}
+
+function triggerBrowserDownload(href: string, filename: string) {
+  const anchor = document.createElement("a");
+  anchor.href = href;
+  anchor.download = filename;
+  anchor.rel = "noopener noreferrer";
+  anchor.style.display = "none";
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+}
+
+async function copyText(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {}
+
+  try {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.left = "-9999px";
+    textarea.style.top = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    const ok = document.execCommand("copy");
+    textarea.remove();
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
 export function SubscriptionDashboardSurface({ adapter }: Props) {
   const { user, isLoading: userLoading, fetchUser } = useUserStore();
   const [subscriptions, setSubscriptions] = React.useState<Subscription[]>([]);
@@ -147,9 +195,33 @@ export function SubscriptionDashboardSurface({ adapter }: Props) {
   }, [subscriptions, user]);
 
   const copyToClipboard = async (subscriptionUrl: string, id: string) => {
-    await navigator.clipboard.writeText(subscriptionUrl);
+    const copied = await copyText(subscriptionUrl);
+    if (!copied) {
+      toast({ title: "复制失败，请手动复制订阅链接", variant: "destructive" });
+      return;
+    }
     setCopiedId(id);
     setTimeout(() => setCopiedId(null), 2000);
+  };
+
+  const downloadSubscription = async (subscription: Subscription) => {
+    const filename = buildYamlDownloadFilename(subscription.name);
+    try {
+      const response = await fetch(subscription.subscriptionUrl);
+      if (!response.ok) throw new Error(`Download failed with status ${response.status}`);
+      const blob = await response.blob();
+      const objectUrl = URL.createObjectURL(blob);
+      triggerBrowserDownload(objectUrl, filename);
+      setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+    } catch (error) {
+      console.error("Failed to fetch subscription YAML for download:", error);
+      triggerBrowserDownload(subscription.subscriptionUrl, filename);
+      toast({
+        title: "已改用浏览器直接下载",
+        description: "如果仍然打开新页面，请稍后刷新页面后再试。",
+        variant: "warning",
+      });
+    }
   };
 
   const deleteSubscription = async (id: string) => {
@@ -329,6 +401,7 @@ export function SubscriptionDashboardSurface({ adapter }: Props) {
                   editHref={editSubscriptionHref(sub)}
                   onCopy={copyToClipboard}
                   onDelete={deleteSubscription}
+                  onDownload={downloadSubscription}
                   onRefresh={refreshSubscription}
                   onSettings={openSubscriptionSettings}
                 />
@@ -420,6 +493,7 @@ function SubscriptionRow({
   editHref,
   onCopy,
   onDelete,
+  onDownload,
   onRefresh,
   onSettings,
 }: {
@@ -429,6 +503,7 @@ function SubscriptionRow({
   editHref: string;
   onCopy: (subscriptionUrl: string, id: string) => Promise<void>;
   onDelete: (id: string) => Promise<void>;
+  onDownload: (sub: Subscription) => Promise<void>;
   onRefresh: (id: string) => Promise<void>;
   onSettings: (sub: Subscription) => void;
 }) {
@@ -514,12 +589,16 @@ function SubscriptionRow({
             </>
           )}
         </Button>
-        <a href={sub.subscriptionUrl} target="_blank" rel="noopener noreferrer">
-          <Button variant="ghost" size="sm" className="gap-0 sm:gap-2" title="下载订阅配置">
-            <Download className="h-4 w-4" />
-            <span className="hidden sm:inline">下载</span>
-          </Button>
-        </a>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => void onDownload(sub)}
+          className="gap-0 sm:gap-2"
+          title="下载订阅配置"
+        >
+          <Download className="h-4 w-4" />
+          <span className="hidden sm:inline">下载</span>
+        </Button>
         <Button
           variant="ghost"
           size="sm"

--- a/packages/ui/src/dashboard/subscription-dashboard-surface.tsx
+++ b/packages/ui/src/dashboard/subscription-dashboard-surface.tsx
@@ -215,11 +215,10 @@ export function SubscriptionDashboardSurface({ adapter }: Props) {
       setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
     } catch (error) {
       console.error("Failed to fetch subscription YAML for download:", error);
-      triggerBrowserDownload(subscription.subscriptionUrl, filename);
       toast({
-        title: "已改用浏览器直接下载",
-        description: "如果仍然打开新页面，请稍后刷新页面后再试。",
-        variant: "warning",
+        title: "下载失败",
+        description: "请刷新页面后重试，或先复制订阅链接到代理软件。",
+        variant: "destructive",
       });
     }
   };


### PR DESCRIPTION
Update public main with the dashboard subscription download fixes already validated before merge.

Scope:
- Fix dashboard download behavior for self-host/local surfaces.
- Preserve extensionless subscription profile names while browser downloads use .yaml.
- No release notes, version, announcement, or documentation copy changes.