### PR TITLE
Fix same-version selfhost image updates

### DIFF
--- a/local/scripts/install.sh
+++ b/local/scripts/install.sh
@@ -620,6 +620,7 @@ main() {
   compose pull
   say "Starting SubBoost..."
   compose up -d --remove-orphans
+  compose up -d --no-deps --force-recreate app
   wait_for_health "$(env_value SUBBOOST_PORT)"
 
   say ""

--- a/local/scripts/subboost.sh
+++ b/local/scripts/subboost.sh
@@ -252,6 +252,7 @@ update_cmd() {
   fi
   compose pull
   compose up -d --remove-orphans
+  compose up -d --no-deps --force-recreate app
   status_cmd
 }
 
@@ -291,6 +292,7 @@ EOF
 
 restart_cmd() {
   compose up -d --remove-orphans
+  compose up -d --no-deps --force-recreate app
   status_cmd
 }
 


### PR DESCRIPTION
Ensure same-version self-host hotfix updates recreate the app container after release.json changes SUBBOOST_IMAGE to a new digest.

Scope:
- Force-recreate only the app service after install/update/restart compose up.
- Do not touch database volumes.
- No release notes, version, announcement, or documentation copy changes.