### PR TITLE
fix: pin Hono security patch

### DIFF
--- a/local/package.json
+++ b/local/package.json
@@ -71,6 +71,7 @@
   },
   "overrides": {
     "@hono/node-server": "1.19.13",
+    "hono": "4.12.25",
     "postcss": "8.5.15"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6440,9 +6440,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   },
   "overrides": {
     "@hono/node-server": "1.19.13",
+    "hono": "4.12.25",
     "postcss": "8.5.15"
   }
 }


### PR DESCRIPTION
## Summary

- pin transitive Hono dependency to 4.12.25 via npm overrides
- refresh package-lock so Dependabot no longer reports Hono < 4.12.25

## Validation

- npm audit --audit-level=low
- npm ls hono --all
- npm run local:build
- npm run check:public-submodule
- npm run check:public-repository