### PR TITLE
ci: use latest checkout in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4


### PR DESCRIPTION
## Summary

- update CodeQL workflow checkout step to actions/checkout@v6
- remove the Node.js 20 deprecation warning emitted by checkout@v4 on current GitHub runners

## Validation

- parsed workflow YAML with js-yaml
- git diff --check -- .github/workflows/codeql.yml
- npm run check:public-repository