### PR TITLE
Harden self-host manager checks

### DIFF
--- a/local/scripts/install.sh
+++ b/local/scripts/install.sh
@@ -72,10 +72,11 @@ prompt() {
     printf '%s\n' "$default_value"
     return 0
   fi
-  if [ -r /dev/tty ] && [ -w /dev/tty ]; then
-    printf '%s' "$message" > /dev/tty
-    IFS= read -r answer < /dev/tty || answer=""
-    printf '\n' > /dev/tty
+  if { exec 3<>/dev/tty; } 2>/dev/null; then
+    printf '%s' "$message" >&3
+    IFS= read -r answer <&3 || answer=""
+    printf '\n' >&3
+    exec 3>&-
   else
     answer=""
   fi
@@ -631,6 +632,8 @@ main() {
   say "重要提醒: 请把 $ENV_FILE 和数据库备份一起保存好。"
 }
 
-trap 'rm -rf "$TMP_DIR"' EXIT
-DOCKER_RUNNER="docker"
-main "$@"
+if [ "${SUBBOOST_SCRIPT_SOURCE_ONLY:-0}" != "1" ]; then
+  trap 'rm -rf "$TMP_DIR"' EXIT
+  DOCKER_RUNNER="docker"
+  main "$@"
+fi

--- a/local/scripts/selfhost-shell.test.ts
+++ b/local/scripts/selfhost-shell.test.ts
@@ -147,4 +147,72 @@ ENV
     expect(result.stdout).toContain("健康检查: 正常");
     expect(result.stdout).toContain("Doctor: OK");
   });
+
+  it("updates exact env keys without removing similarly prefixed names", () => {
+    const script = `
+      set -Eeuo pipefail
+      home="$(mktemp -d)"
+      trap 'rm -rf "$home"' EXIT
+      export SUBBOOST_SCRIPT_SOURCE_ONLY=1
+      export SUBBOOST_HOME="$home"
+      source local/scripts/subboost.sh
+      install_secret_file() {
+        cp "$1" "$2"
+      }
+      read_env_file() {
+        cat "$ENV_FILE"
+      }
+      cat > "$ENV_FILE" <<'ENV'
+SUBBOOST_PORT_EXTRA=keep
+SUBBOOST_PORT=3000
+APP_URL=http://old.example
+ENV
+      write_env_value SUBBOOST_PORT 31000
+      cat "$ENV_FILE"
+    `;
+
+    const result = runBash(script);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("SUBBOOST_PORT_EXTRA=keep");
+    expect(result.stdout).toContain("SUBBOOST_PORT=31000");
+    expect(result.stdout).not.toContain("SUBBOOST_PORT=3000");
+  });
+
+  it("prunes old backups without parsing ls output", () => {
+    const script = `
+      set -Eeuo pipefail
+      base="$(mktemp -d)"
+      home="$base/subboost home"
+      mkdir -p "$home/backups"
+      trap 'rm -rf "$base"' EXIT
+      export SUBBOOST_SCRIPT_SOURCE_ONLY=1
+      export SUBBOOST_HOME="$home"
+      source local/scripts/subboost.sh
+      sudo_do() { "$@"; }
+      load_env() { :; }
+      compose() { printf 'dump'; }
+      cat > "$ENV_FILE" <<'ENV'
+POSTGRES_DB=subboost
+POSTGRES_USER=subboost
+ENV
+      for i in $(seq -w 1 12); do
+        : > "$BACKUP_DIR/subboost-20240101T0000\${i}Z.sql.gz"
+        : > "$BACKUP_DIR/subboost-20240101T0000\${i}Z.env"
+      done
+      backup_cmd >/dev/null
+      sql_count="$(find "$BACKUP_DIR" -maxdepth 1 -type f -name 'subboost-*.sql.gz' | wc -l | tr -d '[:space:]')"
+      env_count="$(find "$BACKUP_DIR" -maxdepth 1 -type f -name 'subboost-*.env' | wc -l | tr -d '[:space:]')"
+      printf 'sql=%s env=%s\\n' "$sql_count" "$env_count"
+      [ "$sql_count" = "10" ]
+      [ "$env_count" = "10" ]
+      [ ! -e "$BACKUP_DIR/subboost-20240101T000001Z.sql.gz" ]
+      [ ! -e "$BACKUP_DIR/subboost-20240101T000001Z.env" ]
+    `;
+
+    const result = runBash(script);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("sql=10 env=10");
+  });
 });

--- a/local/scripts/selfhost-shell.test.ts
+++ b/local/scripts/selfhost-shell.test.ts
@@ -1,0 +1,150 @@
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const publicRoot = path.resolve(__dirname, "../..");
+
+function runBash(script: string) {
+  return spawnSync("bash", ["-lc", "setsid bash -s"], {
+    cwd: publicRoot,
+    encoding: "utf8",
+    input: script,
+    timeout: 10_000,
+    env: {
+      ...process.env,
+      LC_ALL: "C.UTF-8",
+    },
+  });
+}
+
+describe("self-host shell scripts", () => {
+  it("uses prompt defaults without /dev/tty errors in non-interactive mode", () => {
+    const result = runBash(`
+      set -Eeuo pipefail
+      export SUBBOOST_SCRIPT_SOURCE_ONLY=1
+      source local/scripts/install.sh
+      export SUBBOOST_ASSUME_YES=0
+      value="$(prompt 'Question: ' 'default-value')"
+      printf 'value=%s\\n' "$value"
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("value=default-value");
+    expect(result.stderr).not.toContain("/dev/tty");
+  });
+
+  it("does not report Doctor OK when health checks fail", () => {
+    const script = `
+      set -Eeuo pipefail
+      home="$(mktemp -d)"
+      trap 'rm -rf "$home"' EXIT
+      cat > "$home/.env" <<'ENV'
+SUBBOOST_IMAGE=image
+POSTGRES_DB=subboost
+POSTGRES_USER=subboost
+POSTGRES_PASSWORD=password
+DATABASE_URL=postgresql://subboost:password@db:5432/subboost?schema=public
+ENCRYPTION_KEY=key
+JWT_SECRET=jwt
+CRON_SECRET=cron
+APP_URL=http://127.0.0.1:31000
+SUBBOOST_PORT=31000
+ENV
+      : > "$home/docker-compose.yml"
+      export SUBBOOST_SCRIPT_SOURCE_ONLY=1
+      export SUBBOOST_HOME="$home"
+      export SUBBOOST_DOCTOR_HEALTH_ATTEMPTS=1
+      export SUBBOOST_DOCTOR_HEALTH_INTERVAL_SECONDS=0
+      source local/scripts/subboost.sh
+      docker() {
+        if [ "$1" = "info" ]; then return 0; fi
+        if [ "$1" = "compose" ]; then
+          case "$*" in
+            "compose version"*) return 0 ;;
+            *" config") return 0 ;;
+            *" ps -q app") printf 'app-id\\n'; return 0 ;;
+            *" ps -q db") printf 'db-id\\n'; return 0 ;;
+            *" ps -q cron") printf 'cron-id\\n'; return 0 ;;
+          esac
+        fi
+        if [ "$1" = "inspect" ]; then
+          case "$*" in
+            *".State.Status"*) printf 'running\\n'; return 0 ;;
+            *".State.Health"*) printf 'healthy\\n'; return 0 ;;
+          esac
+        fi
+        return 0
+      }
+      curl() { return 1; }
+      set +e
+      output="$(doctor_cmd 2>&1)"
+      status=$?
+      set -e
+      printf 'status=%s\\n%s\\n' "$status" "$output"
+      [ "$status" -ne 0 ]
+      case "$output" in *"Doctor: OK"*) exit 44 ;; esac
+      case "$output" in *"健康检查: 异常"*) exit 0 ;; *) exit 45 ;; esac
+    `;
+
+    const result = runBash(script);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("status=1");
+    expect(result.stdout).toContain("健康检查: 异常");
+    expect(result.stdout).not.toContain("Doctor: OK");
+    expect(result.stdout).toContain("ERROR: Health check failed: app is not responding.");
+  });
+
+  it("reports Doctor OK only after health checks pass", () => {
+    const script = `
+      set -Eeuo pipefail
+      home="$(mktemp -d)"
+      trap 'rm -rf "$home"' EXIT
+      cat > "$home/.env" <<'ENV'
+SUBBOOST_IMAGE=image
+POSTGRES_DB=subboost
+POSTGRES_USER=subboost
+POSTGRES_PASSWORD=password
+DATABASE_URL=postgresql://subboost:password@db:5432/subboost?schema=public
+ENCRYPTION_KEY=key
+JWT_SECRET=jwt
+CRON_SECRET=cron
+APP_URL=http://127.0.0.1:31000
+SUBBOOST_PORT=31000
+ENV
+      : > "$home/docker-compose.yml"
+      export SUBBOOST_SCRIPT_SOURCE_ONLY=1
+      export SUBBOOST_HOME="$home"
+      export SUBBOOST_DOCTOR_HEALTH_ATTEMPTS=1
+      export SUBBOOST_DOCTOR_HEALTH_INTERVAL_SECONDS=0
+      source local/scripts/subboost.sh
+      docker() {
+        if [ "$1" = "info" ]; then return 0; fi
+        if [ "$1" = "compose" ]; then
+          case "$*" in
+            "compose version"*) return 0 ;;
+            *" config") return 0 ;;
+            *" ps -q app") printf 'app-id\\n'; return 0 ;;
+            *" ps -q db") printf 'db-id\\n'; return 0 ;;
+            *" ps -q cron") printf 'cron-id\\n'; return 0 ;;
+          esac
+        fi
+        if [ "$1" = "inspect" ]; then
+          case "$*" in
+            *".State.Status"*) printf 'running\\n'; return 0 ;;
+            *".State.Health"*) printf 'healthy\\n'; return 0 ;;
+          esac
+        fi
+        return 0
+      }
+      curl() { return 0; }
+      doctor_cmd
+    `;
+
+    const result = runBash(script);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("健康检查: 正常");
+    expect(result.stdout).toContain("Doctor: OK");
+  });
+});

--- a/local/scripts/subboost.sh
+++ b/local/scripts/subboost.sh
@@ -199,16 +199,56 @@ service_status_text() {
 }
 
 health_status_text() {
+  health_status_label "$(health_status_code)"
+}
+
+health_status_code() {
   local port base
   port="$(port_number "${SUBBOOST_PORT:-3000}")"
   base="http://127.0.0.1:$port"
-  if command -v curl >/dev/null 2>&1 && curl -fsS "$base/api/health/live" >/dev/null 2>&1 && curl -fsS "$base/api/health/ready" >/dev/null 2>&1; then
-    printf '正常\n'
-  elif command -v curl >/dev/null 2>&1 && curl -fsS "$base/api/health/live" >/dev/null 2>&1; then
-    printf '应用已启动，数据库未就绪\n'
+  if ! command -v curl >/dev/null 2>&1; then
+    printf 'curl-missing\n'
+  elif curl -fsS "$base/api/health/live" >/dev/null 2>&1 && curl -fsS "$base/api/health/ready" >/dev/null 2>&1; then
+    printf 'ok\n'
+  elif curl -fsS "$base/api/health/live" >/dev/null 2>&1; then
+    printf 'not-ready\n'
   else
-    printf '异常\n'
+    printf 'unhealthy\n'
   fi
+}
+
+health_status_label() {
+  case "$1" in
+    ok) printf '正常\n' ;;
+    not-ready) printf '应用已启动，数据库未就绪\n' ;;
+    curl-missing) printf '缺少 curl\n' ;;
+    *) printf '异常\n' ;;
+  esac
+}
+
+wait_for_health() {
+  local attempts="${SUBBOOST_DOCTOR_HEALTH_ATTEMPTS:-15}"
+  local interval="${SUBBOOST_DOCTOR_HEALTH_INTERVAL_SECONDS:-2}"
+  local index status
+  for index in $(seq 1 "$attempts"); do
+    status="$(health_status_code)"
+    if [ "$status" = "ok" ]; then
+      return 0
+    fi
+    if [ "$index" != "$attempts" ]; then
+      sleep "$interval"
+    fi
+  done
+  return 1
+}
+
+doctor_health_failure_message() {
+  local status="$1"
+  case "$status" in
+    not-ready) printf 'Health check failed: database is not ready.' ;;
+    curl-missing) printf 'Health check failed: curl command is missing.' ;;
+    *) printf 'Health check failed: app is not responding.' ;;
+  esac
 }
 
 status_cmd() {
@@ -306,6 +346,12 @@ doctor_cmd() {
     grep -q "^$key=" "$ENV_FILE" || die "Missing $key in $ENV_FILE"
   done
   compose config >/dev/null
+  if ! wait_for_health; then
+    local health_status
+    health_status="$(health_status_code)"
+    status_cmd
+    die "$(doctor_health_failure_message "$health_status")"
+  fi
   status_cmd
   say "Doctor: OK"
 }
@@ -351,6 +397,8 @@ main() {
   esac
 }
 
-trap 'rm -rf "$TMP_DIR"' EXIT
-DOCKER_RUNNER=""
-main "$@"
+if [ "${SUBBOOST_SCRIPT_SOURCE_ONLY:-0}" != "1" ]; then
+  trap 'rm -rf "$TMP_DIR"' EXIT
+  DOCKER_RUNNER=""
+  main "$@"
+fi

--- a/local/scripts/subboost.sh
+++ b/local/scripts/subboost.sh
@@ -126,7 +126,7 @@ write_env_value() {
   local value="$2"
   local tmp="$TMP_DIR/env"
   mkdir -p "$TMP_DIR"
-  read_env_file | awk -v key="$key" 'index($0, key "=") != 1 { print }' > "$tmp"
+  read_env_file | awk -F= -v key="$key" '$1 != key { print }' > "$tmp"
   printf '%s=%s\n' "$key" "$value" >> "$tmp"
   install_secret_file "$tmp" "$ENV_FILE"
 }
@@ -304,27 +304,27 @@ backup_cmd() {
   load_env
   sudo_do mkdir -p "$BACKUP_DIR"
   local stamp db_tmp db_out env_out
+  local -a sql_backups env_backups
+  local i
   stamp="$(date -u +%Y%m%dT%H%M%SZ)"
   db_tmp="$BACKUP_DIR/subboost-$stamp.sql.gz.partial"
   db_out="$BACKUP_DIR/subboost-$stamp.sql.gz"
   env_out="$BACKUP_DIR/subboost-$stamp.env"
   compose exec -T db pg_dump -U "${POSTGRES_USER:-subboost}" -d "${POSTGRES_DB:-subboost}" | gzip -c | sudo_do tee "$db_tmp" >/dev/null
   sudo_do mv "$db_tmp" "$db_out"
-  if is_root; then
-    install -m 600 "$ENV_FILE" "$env_out"
-  else
-    sudo install -m 600 "$ENV_FILE" "$env_out"
-  fi
-  while IFS= read -r old_file; do
-    [ -n "$old_file" ] && sudo_do rm -f "$old_file"
-  done <<EOF
-$(ls -1t "$BACKUP_DIR"/subboost-*.sql.gz 2>/dev/null | sed -n '11,$p')
-EOF
-  while IFS= read -r old_file; do
-    [ -n "$old_file" ] && sudo_do rm -f "$old_file"
-  done <<EOF
-$(ls -1t "$BACKUP_DIR"/subboost-*.env 2>/dev/null | sed -n '11,$p')
-EOF
+  sudo_do install -m 600 "$ENV_FILE" "$env_out"
+
+  shopt -s nullglob
+  sql_backups=("$BACKUP_DIR"/subboost-*.sql.gz)
+  env_backups=("$BACKUP_DIR"/subboost-*.env)
+  shopt -u nullglob
+
+  for ((i = 0; i < ${#sql_backups[@]} - 10; i++)); do
+    sudo_do rm -f -- "${sql_backups[$i]}"
+  done
+  for ((i = 0; i < ${#env_backups[@]} - 10; i++)); do
+    sudo_do rm -f -- "${env_backups[$i]}"
+  done
   say "Backup written:"
   say "  $db_out"
   say "  $env_out"

--- a/packages/core/src/rules/custom-rule-utils.ts
+++ b/packages/core/src/rules/custom-rule-utils.ts
@@ -25,19 +25,19 @@ function toTrimmedString(value: unknown): string {
 }
 
 function toSlug(value: string): string {
-  let out = "";
+  const parts: string[] = [];
   let pendingDash = false;
   for (const char of value.toLowerCase()) {
     const isAsciiLetterOrDigit = (char >= "a" && char <= "z") || (char >= "0" && char <= "9");
     if (isAsciiLetterOrDigit) {
-      if (pendingDash && out) out += "-";
-      out += char;
+      if (pendingDash && parts.length > 0) parts.push("-");
+      parts.push(char);
       pendingDash = false;
     } else {
       pendingDash = true;
     }
   }
-  return out || "item";
+  return parts.length > 0 ? parts.join("") : "item";
 }
 
 function buildDeterministicCustomRuleId(rule: Pick<CustomRule, "type" | "value" | "target">, index: number): string {

--- a/packages/ui/src/store/config-store/source-actions.ts
+++ b/packages/ui/src/store/config-store/source-actions.ts
@@ -40,8 +40,17 @@ type SourceActions = Pick<
 >;
 
 function pickUrlFetchParseResult(fetched: Awaited<ReturnType<typeof fetchUrlContentInBrowser>>): ParseResult | null {
-  if (!fetched.parseResult) return null;
-  return fetched.parseResult;
+  return fetched.parseResult ?? null;
+}
+
+function toSubscriptionImportErrorInfo(error: unknown, fallbackMessage = "解析失败"): SubscriptionImportErrorInfo {
+  if (isSubscriptionImportError(error)) return error.info;
+  const message = error instanceof Error ? error.message : fallbackMessage;
+  return createSubscriptionImportErrorInfo({
+    category: inferSubscriptionImportErrorCategory(message),
+    message,
+    detail: message,
+  });
 }
 
 export function createSourceActions(set: SetState, get: GetState, setAndGenerateConfig: SetAndGenerateConfig): SourceActions {
@@ -248,9 +257,7 @@ export function createSourceActions(set: SetState, get: GetState, setAndGenerate
         const resolvedSubscriptionUserInfo = resolveSubscriptionUserInfo(subscriptionUserInfo, result.nodes);
 
         if (result.nodes.length === 0) {
-          const errorMsg = result.errors.length > 0
-            ? result.errors[0]
-            : "未解析到有效节点";
+          const errorMsg = result.errors[0] ?? "未解析到有效节点";
           throw new Error(errorMsg);
         }
 
@@ -334,15 +341,7 @@ export function createSourceActions(set: SetState, get: GetState, setAndGenerate
           };
         });
       } catch (error) {
-        const baseInfo = (() => {
-          if (isSubscriptionImportError(error)) return error.info;
-          const message = error instanceof Error ? error.message : "解析失败";
-          return createSubscriptionImportErrorInfo({
-            category: inferSubscriptionImportErrorCategory(message),
-            message,
-            detail: message,
-          });
-        })();
+        const baseInfo = toSubscriptionImportErrorInfo(error);
         const shouldHintProxyProviders =
           source.type === "url" &&
           !source.useProxyProviders &&
@@ -455,15 +454,7 @@ export function createSourceActions(set: SetState, get: GetState, setAndGenerate
                 }
               }
             } catch (fetchError) {
-              const baseInfo = (() => {
-                if (isSubscriptionImportError(fetchError)) return fetchError.info;
-                const message = fetchError instanceof Error ? fetchError.message : "未知错误";
-                return createSubscriptionImportErrorInfo({
-                  category: inferSubscriptionImportErrorCategory(message),
-                  message,
-                  detail: message,
-                });
-              })();
+              const baseInfo = toSubscriptionImportErrorInfo(fetchError, "未知错误");
               const shouldHintProxyProviders =
                 !source.useProxyProviders &&
                 !/无效的 url/i.test(baseInfo.message) &&
@@ -517,15 +508,7 @@ export function createSourceActions(set: SetState, get: GetState, setAndGenerate
             lastParsedNameTemplate: currentNameTemplate || undefined,
           });
         } catch (error) {
-          const baseInfo = (() => {
-            if (isSubscriptionImportError(error)) return error.info;
-            const message = error instanceof Error ? error.message : "未知错误";
-            return createSubscriptionImportErrorInfo({
-              category: inferSubscriptionImportErrorCategory(message),
-              message,
-              detail: message,
-            });
-          })();
+          const baseInfo = toSubscriptionImportErrorInfo(error, "未知错误");
           const shouldHintProxyProviders =
             source.type === "url" &&
             !source.useProxyProviders &&
@@ -561,18 +544,18 @@ export function createSourceActions(set: SetState, get: GetState, setAndGenerate
           continue;
         }
 
-        const mergedSourceIds = getNodeSourceIds(existing);
+        const mergedSourceIds = new Set(getNodeSourceIds(existing));
         let changed = false;
         for (const id of getNodeSourceIds(node)) {
-          if (mergedSourceIds.includes(id)) continue;
-          mergedSourceIds.push(id);
+          if (mergedSourceIds.has(id)) continue;
+          mergedSourceIds.add(id);
           changed = true;
         }
         if (!changed) continue;
 
         uniqueNodeMap.set(
           key,
-          ({ ...(existing as unknown as Record<string, unknown>), [SOURCE_IDS_KEY]: mergedSourceIds } as unknown as ParsedNode)
+          ({ ...(existing as unknown as Record<string, unknown>), [SOURCE_IDS_KEY]: Array.from(mergedSourceIds) } as unknown as ParsedNode)
         );
       }
       const uniqueNodes = Array.from(uniqueNodeMap.values());


### PR DESCRIPTION
## Summary
- harden self-host install and doctor readiness checks
- address code quality suggestions in the self-host manager script and shared config helpers
- add shell tests for exact env-key replacement and backup pruning

## Validation
- bash -n local/scripts/subboost.sh
- npm run test:unit -- local/scripts/selfhost-shell.test.ts packages/ui/src/store/config-store/source-actions.test.ts packages/ui/src/store/config-store/source-actions-multiple.test.ts packages/core/src/rules/custom-rule-utils.test.ts
- git diff --check
- npm run lint
- npm run local:typecheck
- npm run local:build
- npm run test:unit

No release, tag, or deploy.