### PR TITLE
docs: add community feedback links

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -62,6 +62,7 @@ npm run check:local-app
 - 部署文档：[https://docs.subboost.org](https://docs.subboost.org)
 - 发行公告：[docs/release-notes.md](./docs/release-notes.md)
 - 更新日志：[https://subboost.org/faq](https://subboost.org/faq)
+- 社区反馈：[LINUX DO](https://linux.do/) & [IDC Flare](https://idcflare.com/)；同时感谢论坛中小伙伴们的积极讨论和反馈
 
 ## 开源许可
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ npm run check:local-app
 - Deployment docs: [https://docs.subboost.org](https://docs.subboost.org)
 - Release announcements: [docs/release-notes.md](./docs/release-notes.md)
 - Changelog: [https://subboost.org/faq](https://subboost.org/faq)
+- Community feedback: [LINUX DO](https://linux.do/) & [IDC Flare](https://idcflare.com/); thanks to everyone in the forums for the active discussion and feedback.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Add LINUX DO and IDC Flare community feedback links to the Chinese README.
- Keep the English README in sync with the same community feedback note.

## Impact

This makes the public README point readers to the community discussion channels and thanks forum members for their feedback.

## Checks

- `git -C public diff --check -- README-CN.md README.md`
- `git -C public diff --check HEAD~1..HEAD`
