### PR TITLE
docs: polish README link copy

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -34,10 +34,10 @@
 
 ## 使用和部署
 
-- [**在线入口**：无需部署，直接使用的公益服务。](https://subboost.org/)
+- 在线入口：[无需部署 - 直接使用的公益服务](https://subboost.org)
 - 部署文档：[一键部署 - 拉取镜像构建，速度快配置要求低](https://docs.subboost.org/deploy/one-click)
 - 部署文档：[高级部署 - 编译源码构建，速度慢配置要求高](https://docs.subboost.org/deploy/advanced)
-- [**配置教程**：草履虫也能学会的 Clash 配置：UI 界面一键配置精确分流、链式代理。](https://ryanvan.com/t/topic/59?u=ryan)
+- 配置教程：[草履虫也能学会的 Clash 配置：UI 界面一键配置精确分流、链式代理](https://ryanvan.com/t/topic/59?u=ryan)
 
 ## 开发说明
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@
 
 ## Usage & Deployment
 
-- [**Online entry**: A public service that can be used directly without deployment.](https://subboost.org/)
+- Online entry: [No deployment required - direct access to the public service](https://subboost.org)
 - Deployment docs: [One-click deployment - pulls an image to build, faster with lower requirements](https://docs.subboost.org/deploy/one-click)
 - Deployment docs: [Advanced deployment - compiles from source, slower with higher requirements](https://docs.subboost.org/deploy/advanced)
-- [**Configuration guide**: Clash configuration simple enough for a paramecium: configure precise routing and chained proxies from the UI in one click.](https://ryanvan.com/t/topic/59?u=ryan)
+- Configuration guide: [Clash configuration simple enough for a paramecium: configure precise routing and chained proxies from the UI in one click](https://ryanvan.com/t/topic/59?u=ryan)
 
 ## Development Notes
 


### PR DESCRIPTION
## Summary
- Polish the README usage and deployment link copy.
- Keep Chinese and English README wording in sync.

## Validation
- git -C public diff --check -- README-CN.md README.md
- npm run check:public-repository
- npm run check:public-submodule
- npm run check:pre-push-readiness

Release level: none