### PR TITLE
Stabilize rule ordering and readiness checks

### DIFF
--- a/local/app/api/setup/admin/route.test.ts
+++ b/local/app/api/setup/admin/route.test.ts
@@ -51,20 +51,32 @@ describe("local setup admin route", () => {
     mocks.readJsonBody.mockResolvedValueOnce(null);
     expect(await readJson(await POST(new Request("https://local.test/api/setup/admin")))).toMatchObject({
       status: 400,
-      body: { error: "Invalid JSON body.", code: "BAD_REQUEST" },
+      body: { error: "请求格式有误，请刷新页面后重试", code: "BAD_REQUEST" },
     });
 
     mocks.readJsonBody.mockResolvedValueOnce({ username: "ry", password: "long-password", passwordConfirm: "long-password" });
     mocks.count.mockResolvedValueOnce(1);
     expect(await readJson(await POST(new Request("https://local.test/api/setup/admin")))).toMatchObject({
       status: 409,
-      body: { error: "Administrator already exists.", code: "CONFLICT" },
+      body: { error: "已有管理员账号，请直接登录", code: "CONFLICT" },
     });
 
     mocks.readJsonBody.mockResolvedValueOnce({ username: "ry", password: "short", passwordConfirm: "short" });
     expect(await readJson(await POST(new Request("https://local.test/api/setup/admin")))).toMatchObject({
       status: 400,
-      body: { error: "Invalid administrator credentials.", code: "BAD_REQUEST" },
+      body: { error: "密码至少需要 10 个字符", code: "BAD_REQUEST" },
+    });
+
+    mocks.readJsonBody.mockResolvedValueOnce({ username: "", password: "long-password", passwordConfirm: "long-password" });
+    expect(await readJson(await POST(new Request("https://local.test/api/setup/admin")))).toMatchObject({
+      status: 400,
+      body: { error: "请输入管理员账号", code: "BAD_REQUEST" },
+    });
+
+    mocks.readJsonBody.mockResolvedValueOnce({ username: "ry", password: "long-password", passwordConfirm: "different-password" });
+    expect(await readJson(await POST(new Request("https://local.test/api/setup/admin")))).toMatchObject({
+      status: 400,
+      body: { error: "两次输入的密码不一致，请重新确认", code: "BAD_REQUEST" },
     });
   });
 

--- a/local/app/api/setup/admin/route.ts
+++ b/local/app/api/setup/admin/route.ts
@@ -1,23 +1,25 @@
 import bcrypt from "bcryptjs";
 import { NextResponse } from "next/server";
+import { getLocalAdminSetupCredentialError, LOCAL_ADMIN_CREDENTIAL_MESSAGES } from "@local/lib/admin-credentials";
 import { apiError, getStringField, readJsonBody } from "@local/lib/http";
 import { prisma } from "@local/lib/prisma";
 import { sessionCookieOptions, signSession, SESSION_COOKIE } from "@local/lib/session";
 
 export async function POST(request: Request) {
   const body = await readJsonBody(request);
-  if (!body) return apiError("Invalid JSON body.", "BAD_REQUEST", 400);
+  if (!body) return apiError(LOCAL_ADMIN_CREDENTIAL_MESSAGES.invalidJson, "BAD_REQUEST", 400);
 
   const existingCount = await prisma.localAdmin.count();
   if (existingCount > 0) {
-    return apiError("Administrator already exists.", "CONFLICT", 409);
+    return apiError(LOCAL_ADMIN_CREDENTIAL_MESSAGES.adminExists, "CONFLICT", 409);
   }
 
   const username = getStringField(body, "username");
   const password = getStringField(body, "password");
   const passwordConfirm = getStringField(body, "passwordConfirm");
-  if (!username || password.length < 10 || password !== passwordConfirm) {
-    return apiError("Invalid administrator credentials.", "BAD_REQUEST", 400);
+  const credentialError = getLocalAdminSetupCredentialError({ username, password, passwordConfirm });
+  if (credentialError) {
+    return apiError(credentialError, "BAD_REQUEST", 400);
   }
 
   const passwordHash = await bcrypt.hash(password, 12);

--- a/local/scripts/selfhost-shell.test.ts
+++ b/local/scripts/selfhost-shell.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 const publicRoot = path.resolve(__dirname, "../..");
 
 function runBash(script: string) {
-  return spawnSync("bash", ["-lc", "setsid bash -s"], {
+  return spawnSync("bash", ["-lc", "if command -v setsid >/dev/null 2>&1; then exec setsid \"$BASH\" -s; fi; exec \"$BASH\" -s"], {
     cwd: publicRoot,
     encoding: "utf8",
     input: script,

--- a/local/src/components/local-login.test.ts
+++ b/local/src/components/local-login.test.ts
@@ -167,13 +167,30 @@ describe("local login component", () => {
 
     expect(html).toContain("初始化本地管理员账号");
     expect(html).toContain("创建管理员");
+    expect(html).toContain("至少 10 个字符");
     expect(mocks.inputs.find((input) => input.placeholder === "确认密码")).toEqual(
       expect.objectContaining({ autoComplete: "new-password" }),
     );
 
     await mocks.forms[0].onSubmit({ preventDefault: vi.fn() });
 
-    expect(setters[6]).toHaveBeenCalledWith("两次输入的密码不一致");
+    expect(setters[6]).toHaveBeenCalledWith("密码至少需要 10 个字符");
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("shows setup password mismatch errors before sending a request", async () => {
+    installWindow();
+    (globalThis as any).fetch = vi.fn();
+    const { setters } = renderLogin({
+      0: { setupRequired: true, authenticated: false },
+      1: "admin",
+      2: "long-password",
+      3: "different-password",
+    });
+
+    await mocks.forms[0].onSubmit({ preventDefault: vi.fn() });
+
+    expect(setters[6]).toHaveBeenCalledWith("两次输入的密码不一致，请重新确认");
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
@@ -213,8 +230,8 @@ describe("local login component", () => {
     const { setters } = renderLogin({
       0: { setupRequired: true, authenticated: false },
       1: "admin",
-      2: "secret",
-      3: "secret",
+      2: "long-secret",
+      3: "long-secret",
       4: true,
     });
 
@@ -227,7 +244,7 @@ describe("local login component", () => {
       "/api/setup/admin",
       expect.objectContaining({
         method: "POST",
-        body: JSON.stringify({ username: "admin", password: "secret", passwordConfirm: "secret" }),
+        body: JSON.stringify({ username: "admin", password: "long-secret", passwordConfirm: "long-secret" }),
       }),
     );
     expect(setters[6]).toHaveBeenCalledWith("用户名已存在");

--- a/local/src/components/local-login.tsx
+++ b/local/src/components/local-login.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { Eye, EyeOff, Loader2 } from "lucide-react";
+import { getLocalAdminSetupCredentialError, LOCAL_ADMIN_PASSWORD_MIN_LENGTH } from "@local/lib/admin-credentials";
 import { hasAuthConfigHandoff } from "@subboost/ui/store/config-store/auth-handoff";
 
 type AuthState = {
@@ -52,8 +53,11 @@ export function LocalLogin() {
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     setError("");
-    if (setupRequired && password !== passwordConfirm) {
-      setError("两次输入的密码不一致");
+    const credentialError = setupRequired
+      ? getLocalAdminSetupCredentialError({ username, password, passwordConfirm })
+      : "";
+    if (credentialError) {
+      setError(credentialError);
       return;
     }
 
@@ -100,6 +104,7 @@ export function LocalLogin() {
                 <input
                   type={showPassword ? "text" : "password"}
                   autoComplete={setupRequired ? "new-password" : "current-password"}
+                  aria-describedby={setupRequired ? "local-admin-password-help" : undefined}
                   placeholder="密码"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
@@ -113,6 +118,11 @@ export function LocalLogin() {
                   {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
                 </button>
               </div>
+              {setupRequired ? (
+                <p id="local-admin-password-help" className="-mt-1 text-xs text-white/45">
+                  至少 {LOCAL_ADMIN_PASSWORD_MIN_LENGTH} 个字符
+                </p>
+              ) : null}
               {setupRequired ? (
                 <input
                   type={showPassword ? "text" : "password"}

--- a/local/src/lib/admin-credentials.ts
+++ b/local/src/lib/admin-credentials.ts
@@ -1,0 +1,26 @@
+export const LOCAL_ADMIN_PASSWORD_MIN_LENGTH = 10;
+
+export const LOCAL_ADMIN_CREDENTIAL_MESSAGES = {
+  invalidJson: "请求格式有误，请刷新页面后重试",
+  adminExists: "已有管理员账号，请直接登录",
+  usernameRequired: "请输入管理员账号",
+  passwordMinLength: `密码至少需要 ${LOCAL_ADMIN_PASSWORD_MIN_LENGTH} 个字符`,
+  passwordMismatch: "两次输入的密码不一致，请重新确认",
+} as const;
+
+type LocalAdminCredentialInput = {
+  username: string;
+  password: string;
+  passwordConfirm: string;
+};
+
+export function getLocalAdminSetupCredentialError(input: LocalAdminCredentialInput): string {
+  const username = input.username.trim();
+  const password = input.password.trim();
+  const passwordConfirm = input.passwordConfirm.trim();
+
+  if (!username) return LOCAL_ADMIN_CREDENTIAL_MESSAGES.usernameRequired;
+  if (password.length < LOCAL_ADMIN_PASSWORD_MIN_LENGTH) return LOCAL_ADMIN_CREDENTIAL_MESSAGES.passwordMinLength;
+  if (password !== passwordConfirm) return LOCAL_ADMIN_CREDENTIAL_MESSAGES.passwordMismatch;
+  return "";
+}

--- a/packages/core/src/generator/rules.test.ts
+++ b/packages/core/src/generator/rules.test.ts
@@ -76,14 +76,14 @@ describe("rule generator", () => {
   });
 
   it("removes deleted preset module rules from generated rules and providers", () => {
-    const enabledModules = PROXY_GROUP_MODULES.map((module) => module.id);
-    const allPresetRuleIds = PROXY_GROUP_MODULES.flatMap((module) => module.rules.map((rule) => rule.id));
+    const enabledModules = PROXY_GROUP_MODULES.map((proxyModule) => proxyModule.id);
+    const allPresetRuleIds = PROXY_GROUP_MODULES.flatMap((proxyModule) => proxyModule.rules.map((rule) => rule.id));
     const duplicateRuleIds = allPresetRuleIds.filter((id, index) => allPresetRuleIds.indexOf(id) !== index);
 
     expect(duplicateRuleIds).toEqual([]);
 
-    for (const module of PROXY_GROUP_MODULES) {
-      for (const rule of module.rules) {
+    for (const proxyModule of PROXY_GROUP_MODULES) {
+      for (const rule of proxyModule.rules) {
         const config = generateClashConfig({
           nodes: [],
           template: "full",
@@ -94,7 +94,7 @@ describe("rule generator", () => {
             ruleProviderBaseUrl: "https://example.com/rules",
             experimentalCnUseCnRuleSet: false,
           },
-          moduleRuleExclusions: { [module.id]: [rule.id] },
+          moduleRuleExclusions: { [proxyModule.id]: [rule.id] },
         });
         const rules = Array.isArray(config.rules) ? config.rules : [];
         const providers = config["rule-providers"] as Record<string, unknown> | undefined;

--- a/packages/core/src/generator/rules.test.ts
+++ b/packages/core/src/generator/rules.test.ts
@@ -7,6 +7,8 @@ import {
   resolveAppliedRuleOrder,
   resolveModuleName,
 } from "./rules";
+import { generateClashConfig } from "./index";
+import { PROXY_GROUP_MODULES } from "./proxy-groups";
 import type { CustomProxyGroup, CustomRule } from "@subboost/core/types/config";
 
 const customRules: CustomRule[] = [
@@ -63,9 +65,86 @@ describe("rule generator", () => {
     });
     expect(texts).toContain("RULE-SET,media-rule,Media,no-resolve");
     expect(texts).toContain("RULE-SET,apple-tvplus,📺 Streaming");
+    expect(entries.find((entry) => entry.text === "RULE-SET,apple-tvplus,📺 Streaming")).toMatchObject({
+      key: "module:streaming-west:apple-tvplus",
+      kind: "module",
+    });
+    expect(entries.some((entry) => entry.key === "special:apple-tvplus")).toBe(false);
     expect(texts).toContain("RULE-SET,cn,🔒 CN Direct");
     expect(texts).toContain("MATCH,🐟 Final");
     expect(texts.find((text) => text.startsWith("RULE-SET,cn-ip,"))).toBe("RULE-SET,cn-ip,🔒 CN Direct");
+  });
+
+  it("removes deleted preset module rules from generated rules and providers", () => {
+    const enabledModules = PROXY_GROUP_MODULES.map((module) => module.id);
+    const allPresetRuleIds = PROXY_GROUP_MODULES.flatMap((module) => module.rules.map((rule) => rule.id));
+    const duplicateRuleIds = allPresetRuleIds.filter((id, index) => allPresetRuleIds.indexOf(id) !== index);
+
+    expect(duplicateRuleIds).toEqual([]);
+
+    for (const module of PROXY_GROUP_MODULES) {
+      for (const rule of module.rules) {
+        const config = generateClashConfig({
+          nodes: [],
+          template: "full",
+          userConfig: {
+            enabledGroups: enabledModules,
+            enabledRules: enabledModules,
+            customRules: [],
+            ruleProviderBaseUrl: "https://example.com/rules",
+            experimentalCnUseCnRuleSet: false,
+          },
+          moduleRuleExclusions: { [module.id]: [rule.id] },
+        });
+        const rules = Array.isArray(config.rules) ? config.rules : [];
+        const providers = config["rule-providers"] as Record<string, unknown> | undefined;
+
+        expect(rules.filter((line) => line.startsWith(`RULE-SET,${rule.id},`))).toEqual([]);
+        expect(providers?.[rule.id]).toBeUndefined();
+      }
+    }
+  });
+
+  it("handles Apple TV+ deletion and moves without special-rule leftovers", () => {
+    const enabledModules = PROXY_GROUP_MODULES.map((module) => module.id);
+    const baseConfig = {
+      nodes: [],
+      template: "full" as const,
+      userConfig: {
+        enabledGroups: enabledModules,
+        enabledRules: enabledModules,
+        customRules: [],
+        ruleProviderBaseUrl: "https://example.com/rules",
+        experimentalCnUseCnRuleSet: false,
+      },
+    };
+    const deleted = generateClashConfig({
+      ...baseConfig,
+      moduleRuleExclusions: { "streaming-west": ["apple-tvplus"] },
+    });
+    const moved = generateClashConfig({
+      ...baseConfig,
+      moduleRuleExclusions: { "streaming-west": ["apple-tvplus"] },
+      moduleRuleOverrides: {
+        google: [
+          {
+            id: "apple-tvplus",
+            name: "Apple TV+",
+            behavior: "domain",
+            path: "geosite/apple-tvplus.mrs",
+          },
+        ],
+      },
+    });
+
+    expect((deleted.rules as string[]).filter((line) => line.startsWith("RULE-SET,apple-tvplus,"))).toEqual([]);
+    expect((deleted["rule-providers"] as Record<string, unknown> | undefined)?.["apple-tvplus"]).toBeUndefined();
+    expect((moved.rules as string[]).filter((line) => line.startsWith("RULE-SET,apple-tvplus,"))).toEqual([
+      "RULE-SET,apple-tvplus,🔍 谷歌服务",
+    ]);
+    expect((moved["rule-providers"] as Record<string, { url?: string }> | undefined)?.["apple-tvplus"]?.url).toBe(
+      "https://example.com/rules/geosite/apple-tvplus.mrs"
+    );
   });
 
   it("normalizes persisted order in editable-only and full-order modes", () => {
@@ -153,5 +232,13 @@ describe("rule generator", () => {
         ruleOrder: ["custom-rule:missing"],
       })
     ).toEqual([]);
+    expect(
+      normalizePersistedRuleOrder({
+        enabledModules: ["streaming-west"],
+        customRules: [],
+        customProxyGroups: [],
+        ruleOrder: ["special:apple-tvplus", "module:streaming-west:apple-tvplus"],
+      })
+    ).toEqual(["module:streaming-west:apple-tvplus"]);
   });
 });

--- a/packages/core/src/generator/rules.test.ts
+++ b/packages/core/src/generator/rules.test.ts
@@ -106,7 +106,7 @@ describe("rule generator", () => {
   });
 
   it("handles Apple TV+ deletion and moves without special-rule leftovers", () => {
-    const enabledModules = PROXY_GROUP_MODULES.map((module) => module.id);
+    const enabledModules = PROXY_GROUP_MODULES.map((proxyModule) => proxyModule.id);
     const baseConfig = {
       nodes: [],
       template: "full" as const,
@@ -190,7 +190,7 @@ describe("rule generator", () => {
 
   it("keeps inactive preset anchors so deleted or moved rules can restore their full-order position", () => {
     const options = {
-      enabledModules: PROXY_GROUP_MODULES.map((module) => module.id),
+      enabledModules: PROXY_GROUP_MODULES.map((proxyModule) => proxyModule.id),
       customRules: [],
       customProxyGroups: [],
       fallbackPolicyTarget: "DIRECT",
@@ -199,22 +199,22 @@ describe("rule generator", () => {
       .filter((entry) => entry.key !== "special:match")
       .map((entry) => entry.key);
 
-    for (const module of PROXY_GROUP_MODULES) {
-      for (const rule of module.rules) {
-        const sourceKey = `module:${module.id}:${rule.id}`;
-        const targetModuleId = module.id === "google" ? "ai" : "google";
+    for (const proxyModule of PROXY_GROUP_MODULES) {
+      for (const rule of proxyModule.rules) {
+        const sourceKey = `module:${proxyModule.id}:${rule.id}`;
+        const targetModuleId = proxyModule.id === "google" ? "ai" : "google";
         const movedKey = `module:${targetModuleId}:${rule.id}`;
         const baselineIndex = baselineOrder.indexOf(sourceKey);
         expect(baselineIndex).toBeGreaterThanOrEqual(0);
 
         const afterDeleteOrder = normalizePersistedRuleOrder({
           ...options,
-          moduleRuleExclusions: { [module.id]: [rule.id] },
+          moduleRuleExclusions: { [proxyModule.id]: [rule.id] },
           ruleOrder: baselineOrder,
         });
         const afterDeleteApplied = resolveAppliedRuleOrder({
           ...options,
-          moduleRuleExclusions: { [module.id]: [rule.id] },
+          moduleRuleExclusions: { [proxyModule.id]: [rule.id] },
           ruleOrder: afterDeleteOrder,
         });
         const afterRestoreApplied = resolveAppliedRuleOrder({
@@ -223,13 +223,13 @@ describe("rule generator", () => {
         });
         const afterMoveOrder = normalizePersistedRuleOrder({
           ...options,
-          moduleRuleExclusions: { [module.id]: [rule.id] },
+          moduleRuleExclusions: { [proxyModule.id]: [rule.id] },
           moduleRuleOverrides: { [targetModuleId]: [rule] },
           ruleOrder: baselineOrder,
         });
         const afterMoveApplied = resolveAppliedRuleOrder({
           ...options,
-          moduleRuleExclusions: { [module.id]: [rule.id] },
+          moduleRuleExclusions: { [proxyModule.id]: [rule.id] },
           moduleRuleOverrides: { [targetModuleId]: [rule] },
           ruleOrder: afterMoveOrder,
         });

--- a/packages/core/src/generator/rules.test.ts
+++ b/packages/core/src/generator/rules.test.ts
@@ -188,6 +188,61 @@ describe("rule generator", () => {
     })).toEqual(["MATCH,DIRECT"]);
   });
 
+  it("keeps inactive preset anchors so deleted or moved rules can restore their full-order position", () => {
+    const options = {
+      enabledModules: PROXY_GROUP_MODULES.map((module) => module.id),
+      customRules: [],
+      customProxyGroups: [],
+      fallbackPolicyTarget: "DIRECT",
+    };
+    const baselineOrder = buildGeneratedRuleEntries(options)
+      .filter((entry) => entry.key !== "special:match")
+      .map((entry) => entry.key);
+
+    for (const module of PROXY_GROUP_MODULES) {
+      for (const rule of module.rules) {
+        const sourceKey = `module:${module.id}:${rule.id}`;
+        const targetModuleId = module.id === "google" ? "ai" : "google";
+        const movedKey = `module:${targetModuleId}:${rule.id}`;
+        const baselineIndex = baselineOrder.indexOf(sourceKey);
+        expect(baselineIndex).toBeGreaterThanOrEqual(0);
+
+        const afterDeleteOrder = normalizePersistedRuleOrder({
+          ...options,
+          moduleRuleExclusions: { [module.id]: [rule.id] },
+          ruleOrder: baselineOrder,
+        });
+        const afterDeleteApplied = resolveAppliedRuleOrder({
+          ...options,
+          moduleRuleExclusions: { [module.id]: [rule.id] },
+          ruleOrder: afterDeleteOrder,
+        });
+        const afterRestoreApplied = resolveAppliedRuleOrder({
+          ...options,
+          ruleOrder: afterDeleteOrder,
+        });
+        const afterMoveOrder = normalizePersistedRuleOrder({
+          ...options,
+          moduleRuleExclusions: { [module.id]: [rule.id] },
+          moduleRuleOverrides: { [targetModuleId]: [rule] },
+          ruleOrder: baselineOrder,
+        });
+        const afterMoveApplied = resolveAppliedRuleOrder({
+          ...options,
+          moduleRuleExclusions: { [module.id]: [rule.id] },
+          moduleRuleOverrides: { [targetModuleId]: [rule] },
+          ruleOrder: afterMoveOrder,
+        });
+
+        expect(afterDeleteOrder).toContain(sourceKey);
+        expect(afterDeleteApplied).not.toContain(sourceKey);
+        expect(afterRestoreApplied.indexOf(sourceKey)).toBe(baselineIndex);
+        expect(afterMoveOrder).toContain(sourceKey);
+        expect(afterMoveApplied.indexOf(movedKey)).toBe(baselineIndex);
+      }
+    }
+  });
+
   it("keeps missing editable rules near their canonical neighbors in full-order mode", () => {
     const options = {
       enabledModules: ["ad", "private", "global", "final"],

--- a/packages/core/src/generator/rules.test.ts
+++ b/packages/core/src/generator/rules.test.ts
@@ -118,6 +118,7 @@ describe("rule generator", () => {
         experimentalCnUseCnRuleSet: false,
       },
     };
+    const baseline = generateClashConfig(baseConfig);
     const deleted = generateClashConfig({
       ...baseConfig,
       moduleRuleExclusions: { "streaming-west": ["apple-tvplus"] },
@@ -136,7 +137,14 @@ describe("rule generator", () => {
         ],
       },
     });
+    const baselineRules = baseline.rules as string[];
+    const appleTvPlusIndex = baselineRules.indexOf("RULE-SET,apple-tvplus,📺 欧美流媒体");
+    const appleIndex = baselineRules.indexOf("RULE-SET,apple,🍏 苹果服务");
+    const hboIndex = baselineRules.indexOf("RULE-SET,hbo,📺 欧美流媒体");
 
+    expect(appleTvPlusIndex).toBeGreaterThanOrEqual(0);
+    expect(appleTvPlusIndex).toBeLessThan(appleIndex);
+    expect(appleTvPlusIndex).toBeLessThan(hboIndex);
     expect((deleted.rules as string[]).filter((line) => line.startsWith("RULE-SET,apple-tvplus,"))).toEqual([]);
     expect((deleted["rule-providers"] as Record<string, unknown> | undefined)?.["apple-tvplus"]).toBeUndefined();
     expect((moved.rules as string[]).filter((line) => line.startsWith("RULE-SET,apple-tvplus,"))).toEqual([

--- a/packages/core/src/generator/rules.ts
+++ b/packages/core/src/generator/rules.ts
@@ -292,7 +292,6 @@ function buildCanonicalRuleEntries(options: Omit<RulesGenerateOptions, "ruleOrde
   const resolvePolicyTarget = createPolicyTargetResolver({ availablePolicyTargets, fallbackPolicyTarget });
   const editableEntries = buildOrderedEditableEntries(customRules, customProxyGroups, undefined, resolvePolicyTarget);
   let insertedEditableEntries = false;
-  let insertedAppleTvPlusRule = false;
 
   const pushEditableEntries = () => {
     if (insertedEditableEntries || editableEntries.length === 0) return;
@@ -307,14 +306,6 @@ function buildCanonicalRuleEntries(options: Omit<RulesGenerateOptions, "ruleOrde
       pushEditableEntries();
     }
 
-    if (!insertedAppleTvPlusRule && moduleId === "apple" && enabledSet.has("streaming-west")) {
-      insertedAppleTvPlusRule = true;
-      const target = resolvePolicyTarget(resolveModuleName("streaming-west", proxyGroupNameOverrides));
-      entries.push(
-        buildSpecialRuleEntry("special:apple-tvplus", `RULE-SET,apple-tvplus,${target}`, "Apple TV+", target)
-      );
-    }
-
     if (!enabledSet.has(moduleId)) continue;
     processedModules.add(moduleId);
 
@@ -323,9 +314,6 @@ function buildCanonicalRuleEntries(options: Omit<RulesGenerateOptions, "ruleOrde
 
     const effectiveRules = getEffectiveModuleRules(ruleModule, moduleRuleOverrides, moduleRuleExclusions);
     for (const rule of effectiveRules) {
-      if (insertedAppleTvPlusRule && ruleModule.id === "streaming-west" && rule.id === "apple-tvplus") {
-        continue;
-      }
       entries.push(buildModuleRuleEntry(ruleModule, rule, proxyGroupNameOverrides, cnIpNoResolve, resolvePolicyTarget));
     }
   }

--- a/packages/core/src/generator/rules.ts
+++ b/packages/core/src/generator/rules.ts
@@ -291,6 +291,7 @@ function buildCanonicalRuleEntries(options: Omit<RulesGenerateOptions, "ruleOrde
   const enabledSet = new Set(enabledModules);
   const resolvePolicyTarget = createPolicyTargetResolver({ availablePolicyTargets, fallbackPolicyTarget });
   const editableEntries = buildOrderedEditableEntries(customRules, customProxyGroups, undefined, resolvePolicyTarget);
+  const emittedRuleKeys = new Set<string>();
   let insertedEditableEntries = false;
 
   const pushEditableEntries = () => {
@@ -299,11 +300,35 @@ function buildCanonicalRuleEntries(options: Omit<RulesGenerateOptions, "ruleOrde
     entries.push(...editableEntries);
   };
 
+  const pushModuleRuleEntry = (module: ProxyGroupModule, rule: ProxyGroupRule) => {
+    const entry = buildModuleRuleEntry(module, rule, proxyGroupNameOverrides, cnIpNoResolve, resolvePolicyTarget);
+    if (emittedRuleKeys.has(entry.key)) return;
+    emittedRuleKeys.add(entry.key);
+    entries.push(entry);
+  };
+
+  const pushAppleTvPlusAtCanonicalPosition = () => {
+    if (!enabledSet.has("streaming-west")) return;
+    const streamingWestModule = PROXY_GROUP_MODULES.find((item) => item.id === "streaming-west");
+    if (!streamingWestModule) return;
+
+    const appleTvPlusRule = getEffectiveModuleRules(streamingWestModule, moduleRuleOverrides, moduleRuleExclusions)
+      .find((rule) => rule.id === "apple-tvplus");
+    if (!appleTvPlusRule) return;
+
+    // Keep the existing generated order without turning Apple TV+ into a special system rule.
+    pushModuleRuleEntry(streamingWestModule, appleTvPlusRule);
+  };
+
   const processedModules = new Set<string>();
 
   for (const moduleId of RULE_ORDER) {
     if (!insertedEditableEntries && moduleId === "gemini") {
       pushEditableEntries();
+    }
+
+    if (moduleId === "apple") {
+      pushAppleTvPlusAtCanonicalPosition();
     }
 
     if (!enabledSet.has(moduleId)) continue;
@@ -314,7 +339,7 @@ function buildCanonicalRuleEntries(options: Omit<RulesGenerateOptions, "ruleOrde
 
     const effectiveRules = getEffectiveModuleRules(ruleModule, moduleRuleOverrides, moduleRuleExclusions);
     for (const rule of effectiveRules) {
-      entries.push(buildModuleRuleEntry(ruleModule, rule, proxyGroupNameOverrides, cnIpNoResolve, resolvePolicyTarget));
+      pushModuleRuleEntry(ruleModule, rule);
     }
   }
 
@@ -325,7 +350,7 @@ function buildCanonicalRuleEntries(options: Omit<RulesGenerateOptions, "ruleOrde
 
     const effectiveRules = getEffectiveModuleRules(ruleModule, moduleRuleOverrides, moduleRuleExclusions);
     for (const rule of effectiveRules) {
-      entries.push(buildModuleRuleEntry(ruleModule, rule, proxyGroupNameOverrides, cnIpNoResolve, resolvePolicyTarget));
+      pushModuleRuleEntry(ruleModule, rule);
     }
   }
 

--- a/packages/core/src/generator/rules.ts
+++ b/packages/core/src/generator/rules.ts
@@ -2,7 +2,7 @@ import type { CustomProxyGroup, CustomRule } from "@subboost/core/types/config";
 import { getCustomGroupRuleOrderKey, getCustomRuleOrderKey } from "@subboost/core/rules/custom-rule-utils";
 import { resolveProxyGroupModuleName } from "@subboost/core/proxy-group-name";
 import { PROXY_GROUP_MODULES, type ProxyGroupModule, type ProxyGroupRule } from "./proxy-group-modules";
-import { getEffectiveModuleRules, type ModuleRuleExclusions } from "./module-rules";
+import { getEffectiveModuleRules, getModuleRuleOrderKey, type ModuleRuleExclusions } from "./module-rules";
 import { createPolicyTargetResolver } from "./policy-targets";
 
 type CustomRuleLike = Pick<CustomRule, "id" | "type" | "value" | "target" | "noResolve">;
@@ -99,6 +99,11 @@ export function resolveModuleNameFromModule(module: ProxyGroupModule, overrides?
 
 export { getEffectiveModuleRules };
 
+const PRESET_MODULE_RULE_ORDER_KEYS = PROXY_GROUP_MODULES.flatMap((module) =>
+  module.rules.map((rule) => getModuleRuleOrderKey(module.id, rule.id))
+);
+const PRESET_MODULE_RULE_ORDER_KEY_SET = new Set(PRESET_MODULE_RULE_ORDER_KEYS);
+
 function buildModuleRuleEntry(
   module: ProxyGroupModule,
   rule: ProxyGroupRule,
@@ -115,7 +120,7 @@ function buildModuleRuleEntry(
   if (noResolve) text += ",no-resolve";
 
   return {
-    key: `module:${module.id}:${rule.id}`,
+    key: getModuleRuleOrderKey(module.id, rule.id),
     text,
     kind: "module",
     sourceLabel: target,
@@ -242,10 +247,10 @@ function normalizeEditableRuleOrderKeys(ruleOrder: string[] | undefined, editabl
 }
 
 function normalizeFullRuleOrderKeys(ruleOrder: string[] | undefined, allRuleKeys: string[]): string[] {
-  if (allRuleKeys.length === 0) return [];
   const allSet = new Set(allRuleKeys);
-  const cleaned = normalizeRuleOrderInput(ruleOrder).filter((key) => allSet.has(key));
-  return cleaned;
+  return normalizeRuleOrderInput(ruleOrder).filter(
+    (key) => allSet.has(key) || PRESET_MODULE_RULE_ORDER_KEY_SET.has(key)
+  );
 }
 
 function applyEditableOnlyOrder(editableRuleKeys: string[], allRuleKeys: string[], editableOrder: string[]): string[] {
@@ -260,9 +265,34 @@ function applyEditableOnlyOrder(editableRuleKeys: string[], allRuleKeys: string[
 }
 
 function usesFullRuleOrder(ruleOrder: string[] | undefined, editableRuleKeys: string[], allRuleKeys: string[]): boolean {
-  const allSet = new Set(allRuleKeys);
+  const allSet = new Set([...allRuleKeys, ...PRESET_MODULE_RULE_ORDER_KEYS]);
   const editableSet = new Set(editableRuleKeys);
   return normalizeRuleOrderInput(ruleOrder).some((key) => allSet.has(key) && !editableSet.has(key));
+}
+
+function getRuleIdFromModuleRuleOrderKey(key: string): string | null {
+  const parts = key.split(":");
+  if (parts.length !== 3 || parts[0] !== "module") return null;
+  return parts[2] || null;
+}
+
+function insertMovedModuleRuleAtSourceAnchor(
+  orderedKeys: string[],
+  activeRuleKeys: Set<string>,
+  key: string
+): boolean {
+  const ruleId = getRuleIdFromModuleRuleOrderKey(key);
+  if (!ruleId) return false;
+
+  const anchorIndex = orderedKeys.findIndex((candidate) => {
+    if (activeRuleKeys.has(candidate)) return false;
+    if (!PRESET_MODULE_RULE_ORDER_KEY_SET.has(candidate)) return false;
+    return getRuleIdFromModuleRuleOrderKey(candidate) === ruleId;
+  });
+  if (anchorIndex < 0) return false;
+
+  orderedKeys.splice(anchorIndex, 0, key);
+  return true;
 }
 
 export function hasFullRuleOrderKeys(ruleOrder: string[] | undefined): boolean {
@@ -423,8 +453,11 @@ export function resolveAppliedRuleOrder(options: RulesGenerateOptions): string[]
   }
 
   if (usesFullRuleOrder(persistedOrder, editableRuleKeys, allRuleKeys)) {
-    const next = persistedOrder.filter((key) => allRuleKeys.includes(key));
-    const seen = new Set(next);
+    const activeRuleKeySet = new Set(allRuleKeys);
+    const next = persistedOrder.filter(
+      (key) => activeRuleKeySet.has(key) || PRESET_MODULE_RULE_ORDER_KEY_SET.has(key)
+    );
+    const seen = new Set(next.filter((key) => activeRuleKeySet.has(key)));
     const editableSet = new Set(editableRuleKeys);
     const missingEditableKeys = editableRuleKeys.filter((key) => !seen.has(key));
 
@@ -462,11 +495,15 @@ export function resolveAppliedRuleOrder(options: RulesGenerateOptions): string[]
 
     for (const key of allRuleKeys) {
       if (seen.has(key)) continue;
+      if (insertMovedModuleRuleAtSourceAnchor(next, activeRuleKeySet, key)) {
+        seen.add(key);
+        continue;
+      }
       next.push(key);
       seen.add(key);
     }
 
-    return next;
+    return next.filter((key) => activeRuleKeySet.has(key));
   }
 
   return applyEditableOnlyOrder(

--- a/packages/ui/src/product/converter/advanced-mode/sections/filtered-proxy-groups-section.tsx
+++ b/packages/ui/src/product/converter/advanced-mode/sections/filtered-proxy-groups-section.tsx
@@ -354,7 +354,7 @@ export function FilteredProxyGroupsSection({
 
                     {expandedFilteredGroups.has(group.id) && (
                       <div className="px-3 pt-3 pb-3 space-y-3 border-t border-white/10">
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
                           <div className="space-y-1">
                             <div className="text-xs text-white/60">导入源</div>
                             <div className={FILTERED_SOURCE_LIST_HEIGHT_CLASS}>
@@ -433,46 +433,46 @@ export function FilteredProxyGroupsSection({
                               不选择表示匹配所有地区
                             </div>
                           </div>
-                        </div>
 
-                        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                          <div className="space-y-1">
-                            <div className="text-xs text-white/60">包含正则（可选）</div>
-                            <Input
-                              value={group.includeRegex ?? ""}
-                              onChange={(e) =>
-                                updateFilteredProxyGroup(group.id, { includeRegex: e.target.value })
-                              }
-                              placeholder="例如: (IEPL|专线|家宽)"
-                              className="h-8 text-xs bg-white/10"
-                            />
-                          </div>
-                          <div className="space-y-1">
-                            <div className="text-xs text-white/60">排除正则（可选）</div>
-                            <Input
-                              value={group.excludeRegex ?? ""}
-                              onChange={(e) =>
-                                updateFilteredProxyGroup(group.id, { excludeRegex: e.target.value })
-                              }
-                              placeholder="例如: (测试|过期)"
-                              className="h-8 text-xs bg-white/10"
-                            />
-                          </div>
-                          <div className="space-y-1">
-                            <div className="text-xs text-white/60">类型</div>
-                            <ProxyGroupTypeMenu
-                              value={(group.groupType || "select") as ProxyGroupTypeMenuValue}
-                              strategy={group.strategy}
-                              onChange={({ groupType, strategy }) =>
-                                updateFilteredProxyGroup(group.id, {
-                                  groupType,
-                                  ...(groupType === "load-balance"
-                                    ? { strategy: strategy ?? group.strategy ?? DEFAULT_LOAD_BALANCE_STRATEGY }
-                                    : { strategy: undefined }),
-                                })
-                              }
-                              triggerClassName="h-8 text-xs bg-white/10 border-white/10"
-                            />
+                          <div className="space-y-3">
+                            <div className="space-y-1">
+                              <div className="text-xs text-white/60">包含正则（可选）</div>
+                              <Input
+                                value={group.includeRegex ?? ""}
+                                onChange={(e) =>
+                                  updateFilteredProxyGroup(group.id, { includeRegex: e.target.value })
+                                }
+                                placeholder="例如: (IEPL|专线|家宽)"
+                                className="h-8 text-xs bg-white/10"
+                              />
+                            </div>
+                            <div className="space-y-1">
+                              <div className="text-xs text-white/60">排除正则（可选）</div>
+                              <Input
+                                value={group.excludeRegex ?? ""}
+                                onChange={(e) =>
+                                  updateFilteredProxyGroup(group.id, { excludeRegex: e.target.value })
+                                }
+                                placeholder="例如: (测试|过期)"
+                                className="h-8 text-xs bg-white/10"
+                              />
+                            </div>
+                            <div className="space-y-1">
+                              <div className="text-xs text-white/60">类型</div>
+                              <ProxyGroupTypeMenu
+                                value={(group.groupType || "select") as ProxyGroupTypeMenuValue}
+                                strategy={group.strategy}
+                                onChange={({ groupType, strategy }) =>
+                                  updateFilteredProxyGroup(group.id, {
+                                    groupType,
+                                    ...(groupType === "load-balance"
+                                      ? { strategy: strategy ?? group.strategy ?? DEFAULT_LOAD_BALANCE_STRATEGY }
+                                      : { strategy: undefined }),
+                                  })
+                                }
+                                triggerClassName="h-8 text-xs bg-white/10 border-white/10"
+                              />
+                            </div>
                           </div>
                         </div>
 

--- a/packages/ui/src/product/converter/advanced-mode/sections/proxy-groups-custom-rules.test.ts
+++ b/packages/ui/src/product/converter/advanced-mode/sections/proxy-groups-custom-rules.test.ts
@@ -295,6 +295,7 @@ describe("ProxyGroupsCustomRules", () => {
     expect(setters[1]).toHaveBeenCalledWith("example.com");
     mocks.captures.selects[0].onValueChange("IP-CIDR");
     expect(setters[0]).toHaveBeenCalledWith("IP-CIDR");
+    expect(setters[3]).toHaveBeenCalledWith(true);
     mocks.captures.selects[1].onValueChange("DIRECT");
     expect(setters[2]).toHaveBeenCalledWith("DIRECT");
     mocks.captures.switches[0].onCheckedChange(false);
@@ -304,13 +305,14 @@ describe("ProxyGroupsCustomRules", () => {
   it.each([
     ["DOMAIN", "domain"],
     ["IP-CIDR", "ipcidr"],
+    ["IP-CIDR6", "ipcidr"],
     ["GEOIP", "geo"],
     ["PROCESS-NAME", "process"],
     ["DST-PORT", "port"],
   ] as const)(
     "adds a %s rule and records the product interaction kind",
     (type, kind) => {
-      renderRules({ 0: type, 1: " value ", 2: "DIRECT", 3: true });
+      const { setters } = renderRules({ 0: type, 1: " value ", 2: "DIRECT", 3: true });
 
       mocks.captures.buttons
         .find((props) => props.children === "添加规则")
@@ -327,6 +329,7 @@ describe("ProxyGroupsCustomRules", () => {
         source: "manual",
         kind,
       });
+      expect(setters[3]).toHaveBeenCalledWith(type.startsWith("IP-CIDR"));
     },
   );
 

--- a/packages/ui/src/product/converter/advanced-mode/sections/proxy-groups-custom-rules.tsx
+++ b/packages/ui/src/product/converter/advanced-mode/sections/proxy-groups-custom-rules.tsx
@@ -79,6 +79,10 @@ function getProductRuleKind(type: CustomRule["type"]): ProductRuleKind {
   return "unknown";
 }
 
+function isIpCidrRuleType(type: CustomRule["type"]): boolean {
+  return type === "IP-CIDR" || type === "IP-CIDR6";
+}
+
 function getTargetOptions(enabledGroupNames: string[], selected?: string) {
   const options = ["DIRECT", "REJECT", ...enabledGroupNames];
   if (selected && !options.includes(selected)) options.push(selected);
@@ -166,7 +170,13 @@ export function ProxyGroupsCustomRules() {
       kind: getProductRuleKind(newRuleType),
     });
     setNewRuleValue("");
-    setNewRuleNoResolve(false);
+    setNewRuleNoResolve(isIpCidrRuleType(newRuleType));
+  };
+
+  const handleNewRuleTypeChange = (value: string) => {
+    const nextType = value as CustomRule["type"];
+    setNewRuleType(nextType);
+    setNewRuleNoResolve(isIpCidrRuleType(nextType));
   };
 
   const startEditingRule = (rule: CustomRule) => {
@@ -227,7 +237,7 @@ export function ProxyGroupsCustomRules() {
           <div className={RULE_EDIT_PRIMARY_GROUP_CLASS}>
             <Select
               value={newRuleType}
-              onValueChange={(v) => setNewRuleType(v as CustomRule["type"])}
+              onValueChange={handleNewRuleTypeChange}
             >
               <SelectTrigger className="h-7 w-[112px] max-w-full shrink-0 text-xs">
                 <span className="truncate">

--- a/packages/ui/src/store/config-store/actions/proxy-group-actions.test.ts
+++ b/packages/ui/src/store/config-store/actions/proxy-group-actions.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { PROXY_GROUP_MODULES } from "@subboost/core/generator/proxy-groups";
+import { buildGeneratedRuleEntries, resolveAppliedRuleOrder } from "@subboost/core/generator/rules";
 import { initialState } from "../definitions";
 import { createProxyGroupActions } from "./proxy-group-actions";
 
@@ -357,6 +359,70 @@ describe("createProxyGroupActions", () => {
 
     actions.removeModuleRule("ai", "custom-ai");
     expect(getState().moduleRuleOverrides).toEqual({});
+  });
+
+  it("keeps full rule order positions across preset rule remove, restore, hide, and move", () => {
+    const enabledProxyGroups = PROXY_GROUP_MODULES.map((module) => module.id);
+    const baseRuleOptions = {
+      enabledModules: enabledProxyGroups,
+      customRules: [],
+      customProxyGroups: [],
+      moduleRuleOverrides: {},
+      moduleRuleExclusions: {},
+      proxyGroupNameOverrides: {},
+      experimentalCnUseCnRuleSet: true,
+      cnIpNoResolve: true,
+      fallbackPolicyTarget: "DIRECT",
+    };
+    const fullRuleOrder = buildGeneratedRuleEntries(baseRuleOptions)
+      .filter((entry) => entry.key !== "special:match")
+      .map((entry) => entry.key);
+    const openAiKey = "module:ai:openai";
+    const appleTvPlusKey = "module:streaming-west:apple-tvplus";
+    const movedAppleTvPlusKey = "module:google:apple-tvplus";
+    const openAiIndex = fullRuleOrder.indexOf(openAiKey);
+    const appleTvPlusIndex = fullRuleOrder.indexOf(appleTvPlusKey);
+    const getAppliedOrder = () => {
+      const state = getState();
+      return resolveAppliedRuleOrder({
+        ...baseRuleOptions,
+        enabledModules: state.enabledProxyGroups,
+        customRules: state.customRules,
+        customProxyGroups: state.customProxyGroups,
+        moduleRuleOverrides: state.moduleRuleOverrides,
+        moduleRuleExclusions: state.moduleRuleExclusions,
+        proxyGroupNameOverrides: state.proxyGroupNameOverrides,
+        ruleOrder: state.ruleOrder,
+      });
+    };
+    const { actions, getState } = createHarness({
+      enabledProxyGroups,
+      moduleRuleOverrides: {},
+      moduleRuleExclusions: {},
+      proxyGroupNameOverrides: {},
+      experimentalCnUseCnRuleSet: true,
+      cnIpNoResolve: true,
+      ruleOrder: fullRuleOrder,
+      allRulesOrderEditingEnabled: true,
+    });
+
+    actions.removeModuleRule("ai", "openai");
+    expect(getState().ruleOrder).toContain(openAiKey);
+    expect(getAppliedOrder()).not.toContain(openAiKey);
+    actions.restoreModuleRule("ai", "openai");
+    expect(getAppliedOrder().indexOf(openAiKey)).toBe(openAiIndex);
+
+    actions.hideProxyGroup("ai");
+    expect(getState().ruleOrder).toContain(openAiKey);
+    expect(getAppliedOrder()).not.toContain(openAiKey);
+    actions.restoreHiddenProxyGroup("ai");
+    expect(getAppliedOrder().indexOf(openAiKey)).toBe(openAiIndex);
+
+    actions.moveModuleRule("streaming-west", "apple-tvplus", { kind: "module", id: "google" });
+    expect(getState().ruleOrder).toContain(appleTvPlusKey);
+    expect(getAppliedOrder().indexOf(movedAppleTvPlusKey)).toBe(appleTvPlusIndex);
+    actions.moveModuleRule("google", "apple-tvplus", { kind: "module", id: "streaming-west" });
+    expect(getAppliedOrder().indexOf(appleTvPlusKey)).toBe(appleTvPlusIndex);
   });
 
   it("adds preset-only and custom module rules with normalized fallback fields", () => {


### PR DESCRIPTION
## Summary
- Preserve generated rule order anchors when preset rules are deleted, restored, or moved.
- Keep filtered proxy group and setup/admin behavior aligned with the new rule-order handling.
- Stabilize readiness tests for shell-based self-host checks.

## Validation
- npm run lint
- npx vitest run public/packages/core/src/generator/rules.test.ts --reporter=verbose
- npx vitest run public/local/scripts/selfhost-shell.test.ts --reporter=verbose
- npm run test:coverage
- npm run check:pre-push-readiness