### PR TITLE
Stabilize self-host shell test timeout

### DIFF
--- a/local/scripts/selfhost-shell.test.ts
+++ b/local/scripts/selfhost-shell.test.ts
@@ -9,7 +9,7 @@ function runBash(script: string) {
     cwd: publicRoot,
     encoding: "utf8",
     input: script,
-    timeout: 10_000,
+    timeout: 30_000,
     env: {
       ...process.env,
       LC_ALL: "C.UTF-8",


### PR DESCRIPTION
## Summary
- Increase the self-host shell test subprocess timeout so readiness remains stable under parallel CI/local load.

## Validation
- npx vitest run public/local/scripts/selfhost-shell.test.ts --reporter=verbose