### PR TITLE
Harden code quality follow-up fixes

### DIFF
--- a/local/scripts/selfhost-shell.test.ts
+++ b/local/scripts/selfhost-shell.test.ts
@@ -219,7 +219,7 @@ ENV
     expect(result.stdout).not.toContain("健康检查: 异常");
     // wait_for_health stops once ready succeeds, then status_cmd performs one final live+ready check.
     expect(result.stdout).toContain("curl_count=7");
-  });
+  }, 10_000);
 
   it("updates exact env keys without removing similarly prefixed names", () => {
     const script = `

--- a/packages/ui/src/store/config-store/actions/proxy-group-actions.test.ts
+++ b/packages/ui/src/store/config-store/actions/proxy-group-actions.test.ts
@@ -1,31 +1,29 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { PROXY_GROUP_MODULES } from "@subboost/core/generator/proxy-groups";
 import { buildGeneratedRuleEntries, resolveAppliedRuleOrder } from "@subboost/core/generator/rules";
-import { initialState } from "../definitions";
+import { initialState, type ConfigState } from "../definitions";
+import type { SetAndGenerateConfig, StoreState } from "../store-types";
 import { createProxyGroupActions } from "./proxy-group-actions";
 
-type HarnessState = typeof initialState & {
-  enabledProxyGroups?: string[];
-  hiddenProxyGroups?: string[];
-  proxyGroupOrder?: string[];
-};
+type HarnessState = ConfigState & Record<string, unknown>;
 
-function createHarness(overrides: Partial<HarnessState> = {}) {
+function createHarness(overrides: Record<string, unknown> = {}) {
   let state: HarnessState = {
     ...structuredClone(initialState),
     ...overrides,
   };
 
-  const applyPatch = (patch?: Partial<HarnessState> | HarnessState) => {
+  const applyPatch = (patch?: Partial<StoreState> | StoreState | void) => {
     if (!patch || patch === state) return;
-    state = { ...state, ...patch };
+    state = { ...state, ...patch } as HarnessState;
   };
 
-  const setAndGenerateConfig = (updater: (current: HarnessState) => Partial<HarnessState> | void) => {
-    applyPatch(updater(state));
+  const setAndGenerateConfig: SetAndGenerateConfig = (updater) => {
+    // createProxyGroupActions only reads ConfigState fields; actions are outside this test harness.
+    applyPatch(updater(state as unknown as StoreState));
   };
 
-  const actions = createProxyGroupActions(() => undefined, () => state, setAndGenerateConfig);
+  const actions = createProxyGroupActions(() => undefined, () => state as unknown as StoreState, setAndGenerateConfig);
   return { actions, getState: () => state };
 }
 


### PR DESCRIPTION
Follow-up after reviewing the code-quality autofix PRs.

- Keep the proxy group action test harness typed without rejecting intentionally invalid runtime fixtures.
- Give the self-host shell health wait test an explicit timeout for full-suite runs.

Validation run locally:
- npm run lint
- npm run test:unit
- npx tsc --noEmit --pretty false filtered for touched files