### PR TITLE
Align TypeScript test fixtures

### DIFF
--- a/packages/core/src/generator/index.test.ts
+++ b/packages/core/src/generator/index.test.ts
@@ -470,7 +470,7 @@ describe("generateClashConfig", () => {
           alterId: 0,
           cipher: "auto",
           "client-fingerprint": 1,
-        } as ParsedNode,
+        } as unknown as ParsedNode,
         {
           name: "VLESS TCP",
           type: "vless",

--- a/packages/core/src/generator/rules.test.ts
+++ b/packages/core/src/generator/rules.test.ts
@@ -468,7 +468,7 @@ describe("rule generator", () => {
         {
           id: "custom-set",
           name: "Custom Set",
-          behavior: "classical",
+          behavior: "classical" as never,
           path: "https://rules.example.com/custom.yaml",
           target: { kind: "custom", id: "regional" },
           noResolve: true,
@@ -504,7 +504,7 @@ describe("rule generator", () => {
         {
           id: "custom-set",
           name: "Custom Set",
-          behavior: "classical",
+          behavior: "classical" as never,
           path: "https://rules.example.com/custom.yaml",
           target: { kind: "custom", id: "regional" },
           noResolve: true,

--- a/packages/core/src/templates/config-template.test.ts
+++ b/packages/core/src/templates/config-template.test.ts
@@ -182,7 +182,7 @@ describe("validateSubBoostTemplateConfig", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.config.hiddenProxyGroups).toEqual([]);
-    expect(result.config.proxyGroupAdvanced[moduleId]).toEqual({ sourceIds: ["source-a"] });
+    expect(result.config.proxyGroupAdvanced?.[moduleId]).toEqual({ sourceIds: ["source-a"] });
     expect(result.config.customRuleSets).toEqual([]);
     expect(result.config.builtinRuleEdits).toEqual({});
     expect(result.config.proxyGroupNameOverrides).toEqual({});

--- a/packages/ui/src/product/converter/advanced-mode/sections/proxy-group-advanced-panel-interactions.test.ts
+++ b/packages/ui/src/product/converter/advanced-mode/sections/proxy-group-advanced-panel-interactions.test.ts
@@ -79,8 +79,10 @@ function node(name: string): ParsedNode {
   } as ParsedNode;
 }
 
-function flattenElements(value: React.ReactNode): React.ReactElement[] {
-  const out: React.ReactElement[] = [];
+type TestElement = React.ReactElement<Record<string, any>>;
+
+function flattenElements(value: React.ReactNode): TestElement[] {
+  const out: TestElement[] = [];
   const visit = (item: React.ReactNode): void => {
     if (Array.isArray(item)) {
       item.forEach(visit);
@@ -91,7 +93,7 @@ function flattenElements(value: React.ReactNode): React.ReactElement[] {
       visit((item.type as (props: unknown) => React.ReactNode)(item.props));
       return;
     }
-    out.push(item);
+    out.push(item as TestElement);
     visit((item.props as { children?: React.ReactNode }).children);
   };
   visit(value);

--- a/packages/ui/src/product/converter/advanced-mode/sections/proxy-groups-module-card.test.ts
+++ b/packages/ui/src/product/converter/advanced-mode/sections/proxy-groups-module-card.test.ts
@@ -73,6 +73,8 @@ vi.mock("./proxy-groups-module-rules-panel", () => ({
 
 import { ProxyGroupsModuleCard } from "./proxy-groups-module-card";
 
+type ModuleCardProps = React.ComponentProps<typeof ProxyGroupsModuleCard>;
+
 const baseModule: ProxyGroupModule = {
   id: "gemini",
   name: "Gemini",
@@ -86,7 +88,7 @@ const baseModule: ProxyGroupModule = {
   ],
 };
 
-function props(overrides: Record<string, unknown> = {}) {
+function props(overrides: Partial<ModuleCardProps> = {}): ModuleCardProps {
   return {
     module: baseModule,
     display: { full: "Gemini Display" },
@@ -183,10 +185,11 @@ describe("ProxyGroupsModuleCard", () => {
   });
 
   it("handles optional description editing and advanced rule rendering", () => {
+    const onChangeEditingDescription = vi.fn();
     const editingHandlers = props({
       isEditing: true,
       editingDescription: "Draft description",
-      onChangeEditingDescription: vi.fn(),
+      onChangeEditingDescription,
       isRulesExpanded: false,
     });
     renderToStaticMarkup(React.createElement(ProxyGroupsModuleCard, editingHandlers));
@@ -200,16 +203,15 @@ describe("ProxyGroupsModuleCard", () => {
     descriptionInput.onChange({ target: { value: "Updated description" } });
     descriptionInput.onKeyDown({ key: "Enter" });
     descriptionInput.onKeyDown({ key: "Escape" });
-    expect(editingHandlers.onChangeEditingDescription).toHaveBeenCalledWith(
-      "Updated description",
-    );
+    expect(onChangeEditingDescription).toHaveBeenCalledWith("Updated description");
     expect(editingHandlers.onCommitEditing).toHaveBeenCalled();
     expect(editingHandlers.onCancelEditing).toHaveBeenCalled();
 
     mocks.inputs = [];
+    const onChangeEmptyDescription = vi.fn();
     const emptyDescriptionHandlers = props({
       isEditing: true,
-      onChangeEditingDescription: vi.fn(),
+      onChangeEditingDescription: onChangeEmptyDescription,
       isRulesExpanded: false,
     });
     renderToStaticMarkup(
@@ -284,7 +286,7 @@ describe("ProxyGroupsModuleCard", () => {
         ProxyGroupsModuleCard,
         props({
           description: "Override description",
-          module: { ...baseModule, description: undefined },
+          module: { ...baseModule, description: undefined as never },
           display: { full: "Override" },
         })
       )
@@ -297,7 +299,7 @@ describe("ProxyGroupsModuleCard", () => {
         props({
           extraRules: [],
           manualRules: [],
-          module: { ...baseModule, description: undefined, rules: [] },
+          module: { ...baseModule, description: undefined as never, rules: [] },
           rulesContentOverride: null,
           rulesCountOverride: 0,
         })

--- a/packages/ui/src/product/converter/advanced-mode/sections/proxy-groups-rules-library.test.ts
+++ b/packages/ui/src/product/converter/advanced-mode/sections/proxy-groups-rules-library.test.ts
@@ -572,7 +572,7 @@ describe("ProxyGroupsRulesLibrary", () => {
     expect(renderLibrary().html).toContain("域名");
 
     vi.clearAllMocks();
-    mocks.interactions = {};
+    mocks.interactions = { ruleAdded: vi.fn() };
     mocks.store.customRuleSets = [];
     mocks.search.searchResults = [telegramRule];
     renderLibrary({ 0: [telegramRule], 1: "custom:custom-1" });


### PR DESCRIPTION
## Summary
- Align public test fixtures with the current TypeScript contracts.
- Keep runtime behavior unchanged.

## Validation
- npm run lint
- npm run test:unit
- npx tsc --noEmit --incremental false
