### PR TITLE
Fix release installer tag defaults

### DIFF
--- a/scripts/selfhost-release-assets.cjs
+++ b/scripts/selfhost-release-assets.cjs
@@ -175,10 +175,27 @@ function replaceInstallerDefault(content, item, replacement) {
   return content.replace(expected, replacementLine);
 }
 
+function withInferredInstallerDefaults(args) {
+  const inferred = { ...args };
+  const releaseAssetBaseUrl = args.baseUrl || "";
+  const releaseImageTag =
+    args.imageTag || (args.releaseTag ? `${args.imageRepository || DEFAULT_IMAGE_REPOSITORY}:${args.releaseTag}` : "");
+
+  if (releaseAssetBaseUrl) {
+    inferred.installerReleaseUrl = inferred.installerReleaseUrl || urlJoin(releaseAssetBaseUrl, "release.json");
+    inferred.installerComposeUrl =
+      inferred.installerComposeUrl || urlJoin(releaseAssetBaseUrl, "docker-compose.image.yml");
+    inferred.installerManagerUrl = inferred.installerManagerUrl || urlJoin(releaseAssetBaseUrl, MANAGER_ASSET_NAME);
+  }
+  if (releaseAssetBaseUrl && releaseImageTag) inferred.installerImage = inferred.installerImage || releaseImageTag;
+  return inferred;
+}
+
 function rewriteInstallerDefaults(content, args) {
+  const resolvedArgs = withInferredInstallerDefaults(args);
   let output = content;
   for (const item of INSTALLER_DEFAULTS) {
-    const replacement = args[item.key];
+    const replacement = resolvedArgs[item.key];
     if (replacement) output = replaceInstallerDefault(output, item, replacement);
   }
   return output;


### PR DESCRIPTION
## Summary\n- infer installer asset URLs from the release asset base URL\n- pin stable release install.sh defaults to the same release tag and image tag\n\n## Validation\n- npx vitest run service/test/scripts/selfhost-oneclick.test.ts\n- git diff --check