### PR TITLE
ci(release): build arm images on native runners

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -77,7 +77,7 @@ jobs:
       - run: npm run check:local-app
 
   build-image:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: meta
     strategy:
       fail-fast: false
@@ -85,12 +85,12 @@ jobs:
         include:
           - arch: amd64
             platform: linux/amd64
+            runner: ubuntu-latest
           - arch: arm64
             platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
-
-      - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
       - run: npm run check:local-app
 
   build-image:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: meta
     strategy:
       fail-fast: false
@@ -72,12 +72,12 @@ jobs:
         include:
           - arch: amd64
             platform: linux/amd64
+            runner: ubuntu-latest
           - arch: arm64
             platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
-
-      - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
## Summary
- run arm64 image jobs on GitHub's native `ubuntu-24.04-arm` runner
- keep amd64 jobs on `ubuntu-latest`
- remove QEMU setup from both Dev Release and Stable Release workflows

## Evidence
Dev Release run 30212336433 attempt 1 reached the Next production build under QEMU, emitted `qemu: uncaught target signal 4 (Illegal instruction)` twice, then remained in progress until canceled after 30 minutes. Recent successful emulated arm64 builds took roughly 14–15 minutes. GitHub now provides the native arm64 label for public repositories, so emulation is unnecessary.

## Validation
- both workflow files parse as YAML
- `git diff --check`
- `npm run lint`

The final proof is this PR's checks followed by a Dev Release run after merge. No version bump, tag, stable release, or application code change is included.