### PR TITLE
Align local v2.7.0 package metadata

### DIFF
--- a/local/package.json
+++ b/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@subboost/local",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "AGPL-3.0-only",
   "private": true,
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
     },
     "local": {
       "name": "@subboost/local",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@prisma/adapter-pg": "^7.9.0",


### PR DESCRIPTION
## What changed

- Align the local application package version with the v2.7.0 repository version.
- Refresh the corresponding workspace entry in `package-lock.json`.

## Why

The top-level release metadata was updated to v2.7.0, but the local workspace metadata still reported v2.6.0. This follow-up keeps source and lockfile metadata consistent without changing runtime behavior.

## Validation

- `npm run lint`
- `npm run test:unit` (223 files, 1216 tests)
- `npm run check:local-app`
- `git diff --check -- local/package.json package-lock.json`