### PR TITLE
fix(core): 节点内容指纹递归忽略内部 _ 前缀字段

### DIFF
--- a/packages/core/src/node-identity.test.ts
+++ b/packages/core/src/node-identity.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { ParsedNode } from "./types/node";
+import { buildNodeContentKey } from "./node-identity";
+
+// 测试数据全部为虚构，不包含任何真实订阅信息
+function realityNode(name: string, uuid: string, spiderX: string, patch: Record<string, unknown> = {}): ParsedNode {
+  return {
+    name,
+    type: "vless",
+    server: "reality.example.com",
+    port: 443,
+    uuid,
+    tls: true,
+    "client-fingerprint": "chrome",
+    flow: "xtls-rprx-vision",
+    network: "tcp",
+    "reality-opts": {
+      "public-key": "FAKE_PUBLIC_KEY_AAAAAAAAAAAAAAAA",
+      "short-id": "0000",
+      "_spider-x": spiderX,
+    },
+    ...patch,
+  } as unknown as ParsedNode;
+}
+
+const UUID_A = "11111111-1111-1111-1111-111111111111";
+const UUID_B = "22222222-2222-2222-2222-222222222222";
+
+describe("buildNodeContentKey", () => {
+  it("ignores nested internal underscore fields such as reality-opts._spider-x", () => {
+    const stored = realityNode("Reality Node A (v1)", UUID_A, "/spider-old");
+    const fresh = realityNode("Reality Node A (v2)", UUID_A, "/spider-new");
+
+    // spider-x 轮换 + 显示名动态变化，不应改变内容指纹
+    expect(buildNodeContentKey(fresh)).toBe(buildNodeContentKey(stored));
+  });
+
+  it("still distinguishes nodes whose real identity fields differ", () => {
+    const nodeA = realityNode("Node A", UUID_A, "/spider-a");
+    const nodeB = realityNode("Node B", UUID_B, "/spider-a");
+
+    expect(buildNodeContentKey(nodeB)).not.toBe(buildNodeContentKey(nodeA));
+  });
+
+  it("keeps ignoring top-level internal fields (existing behavior)", () => {
+    const base = realityNode("Same Node", UUID_A, "/spider");
+    const withMeta = {
+      ...base,
+      _sourceIds: ["source-a"],
+      _originName: "origin-a",
+      _meta: { importedAt: 1 },
+    };
+
+    expect(buildNodeContentKey(withMeta)).toBe(buildNodeContentKey(base));
+  });
+});

--- a/packages/core/src/node-identity.test.ts
+++ b/packages/core/src/node-identity.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ParsedNode } from "./types/node";
-import { buildNodeContentKey } from "./node-identity";
+import { buildNodeContentKey, stableJsonStringify } from "./node-identity";
 
 // 测试数据全部为虚构，不包含任何真实订阅信息
 function realityNode(name: string, uuid: string, spiderX: string, patch: Record<string, unknown> = {}): ParsedNode {
@@ -25,6 +25,16 @@ function realityNode(name: string, uuid: string, spiderX: string, patch: Record<
 
 const UUID_A = "11111111-1111-1111-1111-111111111111";
 const UUID_B = "22222222-2222-2222-2222-222222222222";
+
+describe("stableJsonStringify", () => {
+  it("preserves nested underscore-prefixed keys for generic serialization", () => {
+    const first = stableJsonStringify({ nested: { _nonce: "a", value: 1 } });
+    const second = stableJsonStringify({ nested: { _nonce: "b", value: 1 } });
+
+    expect(first).toBe('{"nested":{"_nonce":"a","value":1}}');
+    expect(second).not.toBe(first);
+  });
+});
 
 describe("buildNodeContentKey", () => {
   it("ignores nested internal underscore fields such as reality-opts._spider-x", () => {

--- a/packages/core/src/node-identity.ts
+++ b/packages/core/src/node-identity.ts
@@ -7,7 +7,10 @@ export interface NodeContentKeyOptions {
   ignoreServername?: boolean;
 }
 
-export function stableJsonStringify(value: unknown): string {
+function stableJsonStringifyWithKeyFilter(
+  value: unknown,
+  includeKey: (key: string) => boolean
+): string {
   const seen = new WeakSet<object>();
 
   const normalize = (input: unknown): unknown => {
@@ -21,15 +24,17 @@ export function stableJsonStringify(value: unknown): string {
     const keys = Object.keys(obj).sort();
     const out: Record<string, unknown> = {};
     for (const key of keys) {
-      // 与 buildNodeContentKey 顶层行为一致：递归忽略 SubBoost 内部 _ 前缀字段
-      // （如 reality-opts._spider-x，机场每次更新轮换会导致内容指纹变化、节点匹配失败）
-      if (key.startsWith("_")) continue;
+      if (!includeKey(key)) continue;
       out[key] = normalize(obj[key]);
     }
     return out;
   };
 
   return JSON.stringify(normalize(value));
+}
+
+export function stableJsonStringify(value: unknown): string {
+  return stableJsonStringifyWithKeyFilter(value, () => true);
 }
 
 export function buildNodeContentKey(
@@ -48,7 +53,9 @@ export function buildNodeContentKey(
     })
   );
 
-  return stableJsonStringify(filtered);
+  // 节点内部字段不属于内容身份；例如机场轮换 reality-opts._spider-x
+  // 时，节点的稳定身份不应随之变化。
+  return stableJsonStringifyWithKeyFilter(filtered, (key) => !key.startsWith("_"));
 }
 
 export function buildScopedNodeIdentityKey(scope: string, node: ParsedNode): string {

--- a/packages/core/src/node-identity.ts
+++ b/packages/core/src/node-identity.ts
@@ -20,7 +20,12 @@ export function stableJsonStringify(value: unknown): string {
     const obj = input as Record<string, unknown>;
     const keys = Object.keys(obj).sort();
     const out: Record<string, unknown> = {};
-    for (const key of keys) out[key] = normalize(obj[key]);
+    for (const key of keys) {
+      // 与 buildNodeContentKey 顶层行为一致：递归忽略 SubBoost 内部 _ 前缀字段
+      // （如 reality-opts._spider-x，机场每次更新轮换会导致内容指纹变化、节点匹配失败）
+      if (key.startsWith("_")) continue;
+      out[key] = normalize(obj[key]);
+    }
     return out;
   };
 

--- a/packages/core/src/subscription/source-node-refresh-reality.test.ts
+++ b/packages/core/src/subscription/source-node-refresh-reality.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { ParsedNode } from "../types/node";
+import { ORIGIN_NAME_KEY, SOURCE_IDS_KEY } from "./node-source-state";
+import { mergeParsedSourceNodes, prepareSourceParsedNodes } from "./source-node-refresh";
+
+const REALITY_UUID = "11111111-1111-1111-1111-111111111111";
+
+function realityNode(name: string, spiderX: string, patch: Record<string, unknown> = {}): ParsedNode {
+  return {
+    name,
+    type: "vless",
+    server: "reality.example.com",
+    port: 443,
+    uuid: REALITY_UUID,
+    tls: true,
+    "client-fingerprint": "chrome",
+    flow: "xtls-rprx-vision",
+    network: "tcp",
+    udp: true,
+    "reality-opts": {
+      "public-key": "FAKE_PUBLIC_KEY_AAAAAAAAAAAAAAAA",
+      "short-id": "0000",
+      "_spider-x": spiderX,
+    },
+    ...patch,
+  } as ParsedNode;
+}
+
+function ssNode(name: string): ParsedNode {
+  return {
+    name,
+    type: "ss",
+    server: `${name.toLowerCase()}.example.com`,
+    port: 8388,
+    cipher: "aes-128-gcm",
+    password: "secret",
+  } as ParsedNode;
+}
+
+describe("source node refresh reality identity", () => {
+  it("keeps matching a reality node when spider-x rotates and updates its automatic name", () => {
+    const state = [
+      ssNode("before"),
+      realityNode("Reality Node A (v1)", "/spider-old", {
+        [ORIGIN_NAME_KEY]: "Reality Node A (v1)",
+        [SOURCE_IDS_KEY]: ["source-a"],
+      }),
+      ssNode("after"),
+    ];
+    const parsed = prepareSourceParsedNodes([realityNode("Reality Node A (v2)", "/spider-new")], {});
+
+    const result = mergeParsedSourceNodes(state, parsed, [], { sourceId: "source-a" });
+
+    expect(result.nodes.map((node) => node.name)).toEqual(["before", "Reality Node A (v2)", "after"]);
+    expect(result.nodes[1]).toMatchObject({
+      uuid: REALITY_UUID,
+      [ORIGIN_NAME_KEY]: "Reality Node A (v2)",
+      [SOURCE_IDS_KEY]: ["source-a"],
+    });
+    expect(
+      (result.nodes[1] as unknown as { "reality-opts"?: { "_spider-x"?: string } })["reality-opts"]?.["_spider-x"]
+    ).toBe("/spider-new");
+  });
+
+  it("preserves a manual name while refreshing the origin and spider-x", () => {
+    const state = [
+      realityNode("Pinned Reality Name", "/spider-old", {
+        [ORIGIN_NAME_KEY]: "Reality Node A (v1)",
+        [SOURCE_IDS_KEY]: ["source-a"],
+      }),
+    ];
+    const parsed = prepareSourceParsedNodes([realityNode("Reality Node A (v2)", "/spider-new")], {});
+
+    const result = mergeParsedSourceNodes(state, parsed, [], { sourceId: "source-a" });
+
+    expect(result.nodes).toHaveLength(1);
+    expect(result.nodes[0]).toMatchObject({
+      name: "Pinned Reality Name",
+      uuid: REALITY_UUID,
+      [ORIGIN_NAME_KEY]: "Reality Node A (v2)",
+      [SOURCE_IDS_KEY]: ["source-a"],
+    });
+    expect(
+      (result.nodes[0] as unknown as { "reality-opts"?: { "_spider-x"?: string } })["reality-opts"]?.["_spider-x"]
+    ).toBe("/spider-new");
+  });
+});

--- a/packages/core/src/subscription/source-node-refresh.test.ts
+++ b/packages/core/src/subscription/source-node-refresh.test.ts
@@ -555,67 +555,6 @@ describe("source node refresh helpers", () => {
     });
   });
 
-  it("keeps matching a reality node when the airport rotates spider-x but uuid stays stable", () => {
-    // 测试数据全部为虚构，不包含任何真实订阅信息
-    const state = [
-      {
-        name: "Reality Node A (v1)",
-        type: "vless",
-        server: "reality.example.com",
-        port: 443,
-        uuid: "11111111-1111-1111-1111-111111111111",
-        tls: true,
-        "client-fingerprint": "chrome",
-        flow: "xtls-rprx-vision",
-        network: "tcp",
-        udp: true,
-        "reality-opts": {
-          "public-key": "FAKE_PUBLIC_KEY_AAAAAAAAAAAAAAAA",
-          "short-id": "0000",
-          "_spider-x": "/spider-old",
-        },
-        [ORIGIN_NAME_KEY]: "Reality Node A (v1)",
-        [SOURCE_IDS_KEY]: ["source-a"],
-      },
-    ];
-    const parsed = prepareSourceParsedNodes(
-      [
-        {
-          name: "Reality Node A (v2)",
-          type: "vless",
-          server: "reality.example.com",
-          port: 443,
-          uuid: "11111111-1111-1111-1111-111111111111",
-          tls: true,
-          "client-fingerprint": "chrome",
-          flow: "xtls-rprx-vision",
-          network: "tcp",
-          udp: true,
-          "reality-opts": {
-            "public-key": "FAKE_PUBLIC_KEY_AAAAAAAAAAAAAAAA",
-            "short-id": "0000",
-            "_spider-x": "/spider-new",
-          },
-        },
-      ],
-      {}
-    );
-
-    const result = mergeParsedSourceNodes(state, parsed, [], {
-      sourceId: "source-a",
-    });
-
-    // 匹配成功：不产生重复节点，保留原位置与原显示名，spider-x 更新为新值
-    expect(result.nodes).toHaveLength(1);
-    expect(result.nodes[0]).toMatchObject({
-      name: "Reality Node A (v1)",
-      uuid: "11111111-1111-1111-1111-111111111111",
-      [SOURCE_IDS_KEY]: ["source-a"],
-    });
-    expect(
-      (result.nodes[0] as unknown as { "reality-opts"?: { "_spider-x"?: string } })["reality-opts"]?.["_spider-x"]
-    ).toBe("/spider-new");
-  });
 });
 
 describe("subscription response info helpers", () => {

--- a/packages/core/src/subscription/source-node-refresh.test.ts
+++ b/packages/core/src/subscription/source-node-refresh.test.ts
@@ -554,6 +554,68 @@ describe("source node refresh helpers", () => {
       [SOURCE_IDS_KEY]: ["source-b", "source-a"],
     });
   });
+
+  it("keeps matching a reality node when the airport rotates spider-x but uuid stays stable", () => {
+    // 测试数据全部为虚构，不包含任何真实订阅信息
+    const state = [
+      {
+        name: "Reality Node A (v1)",
+        type: "vless",
+        server: "reality.example.com",
+        port: 443,
+        uuid: "11111111-1111-1111-1111-111111111111",
+        tls: true,
+        "client-fingerprint": "chrome",
+        flow: "xtls-rprx-vision",
+        network: "tcp",
+        udp: true,
+        "reality-opts": {
+          "public-key": "FAKE_PUBLIC_KEY_AAAAAAAAAAAAAAAA",
+          "short-id": "0000",
+          "_spider-x": "/spider-old",
+        },
+        [ORIGIN_NAME_KEY]: "Reality Node A (v1)",
+        [SOURCE_IDS_KEY]: ["source-a"],
+      },
+    ];
+    const parsed = prepareSourceParsedNodes(
+      [
+        {
+          name: "Reality Node A (v2)",
+          type: "vless",
+          server: "reality.example.com",
+          port: 443,
+          uuid: "11111111-1111-1111-1111-111111111111",
+          tls: true,
+          "client-fingerprint": "chrome",
+          flow: "xtls-rprx-vision",
+          network: "tcp",
+          udp: true,
+          "reality-opts": {
+            "public-key": "FAKE_PUBLIC_KEY_AAAAAAAAAAAAAAAA",
+            "short-id": "0000",
+            "_spider-x": "/spider-new",
+          },
+        },
+      ],
+      {}
+    );
+
+    const result = mergeParsedSourceNodes(state, parsed, [], {
+      sourceId: "source-a",
+    });
+
+    // 匹配成功：不产生重复节点，保留原位置与原显示名，spider-x 更新为新值
+    expect(result.nodes).toHaveLength(1);
+    expect(result.nodes[0]).toMatchObject({
+      name: "Reality Node A (v1)",
+      uuid: "11111111-1111-1111-1111-111111111111",
+      [SOURCE_IDS_KEY]: ["source-a"],
+    });
+    expect(
+      (result.nodes[0] as unknown as { "reality-opts"?: { "_spider-x"?: string } })["reality-opts"]?.["_spider-x"]
+    ).toBe("/spider-new");
+  });
 });
 
 describe("subscription response info helpers", () => {

--- a/packages/core/src/subscription/source-node-refresh.ts
+++ b/packages/core/src/subscription/source-node-refresh.ts
@@ -332,7 +332,8 @@ export function mergeParsedSourceNodes(
 
     if (sourceIds.includes(sourceId)) {
       hadExistingSourceNodes = true;
-      const originName = resolveOriginName(node, { allowDisplayNameFallback }) ?? originOf(node);
+      const previousOriginName = originOf(node);
+      const originName = resolveOriginName(node, { allowDisplayNameFallback }) ?? previousOriginName;
       const fresh = originName ? takeFresh(originName) : null;
 
       const base = withoutNodeSourceIds(node, removed);
@@ -341,7 +342,7 @@ export function mergeParsedSourceNodes(
         continue;
       }
 
-      const keepUserName = originName ? isUserRenamed(node.name, originName) : false;
+      const keepUserName = previousOriginName ? isUserRenamed(node.name, previousOriginName) : false;
       const desiredName = keepUserName ? node.name : fresh.name;
       const extraIds = base ? getNodeSourceIds(base) : sourceIds.filter((id) => id !== sourceId);
 


### PR DESCRIPTION
## 问题

节点内容指纹（`buildNodeContentKey`）原先只在节点顶层过滤 `_` 前缀的内部字段，嵌套对象里的内部字段仍会参与身份计算。

VLESS Reality 解析器会把 `spider-x` 保存为 `reality-opts._spider-x`。上游轮换这个内部参数时，即使 UUID、服务器、端口等稳定身份字段都没有变化，节点内容指纹仍会改变，导致订阅刷新把已有节点误判为新节点，影响节点顺序和名称刷新。

## 根因

通用稳定 JSON 序列化与节点身份序列化共用了同一条路径，但两者的合同不同：

- 通用 `stableJsonStringify` 应完整保留对象键，包括嵌套的 `_` 前缀键。
- `buildNodeContentKey` 计算节点身份时，应递归忽略 SubBoost 的 `_` 前缀内部字段。

此外，刷新逻辑使用新上游名称判断旧节点是否被用户手动改名，导致“旧显示名等于旧来源名”的自动名称被误认为手动名称，无法随上游更新。

## 修复

- 为稳定 JSON 序列化增加内部键过滤能力，但保持公开的 `stableJsonStringify` 完整序列化所有键。
- 仅在 `buildNodeContentKey` 中递归忽略 `_` 前缀内部字段，使 `_spider-x` 轮换不再改变节点身份。
- 刷新时以旧的 `_originName` 判断用户是否手动改名：
  - 未手动改名的节点采用新的上游显示名。
  - 用户手动名称保持不变。
  - 节点内容、`_originName` 和来源信息继续更新。
- 将 Reality 刷新回归场景拆到独立测试文件，保持原测试文件低于项目行数限制。

## 验证

- 定向测试：3 个文件 / 23 个用例通过。
- Core 测试：65 个文件 / 381 个用例通过。
- 完整覆盖率测试：298 个文件 / 1639 个用例通过。
- `npm run lint` 通过。
- `npm run check:local-app` 通过。
- GitHub CI 与 CodeQL 均在当前 head `22288c0947cb0d80c55b3619bd2beb2dc554dc73` 上通过。
